### PR TITLE
Use local voice list for voice validation

### DIFF
--- a/Orpheus-TTS/orpheus_tts_pypi/orpheus_tts/engine_class.py
+++ b/Orpheus-TTS/orpheus_tts_pypi/orpheus_tts/engine_class.py
@@ -65,9 +65,12 @@ class OrpheusModel:
         return AsyncLLMEngine.from_engine_args(engine_args)
     
     def validate_voice(self, voice):
-        if voice:
-            if voice not in self.engine.available_voices:
-                raise ValueError(f"Voice {voice} is not available for model {self.model_name}")
+        if voice and voice not in self.available_voices:
+            available = ", ".join(self.available_voices)
+            raise ValueError(
+                f"Voice {voice} is not available for model {self.model_name}."
+                f" Supported voices: {available}"
+            )
     
     def _format_prompt(self, prompt, voice="tara", model_type="larger"):
         if model_type == "smaller":


### PR DESCRIPTION
## Summary
- use `self.available_voices` in `validate_voice`
- include supported voice list in validation error

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9ca10158832ca6de455022e08a69