### PR TITLE
Refactor TTS API streaming to async

### DIFF
--- a/Orpheus-FastAPI/requirements.txt
+++ b/Orpheus-FastAPI/requirements.txt
@@ -7,6 +7,7 @@ python-multipart==0.0.6
 
 # API and Communication
 requests==2.31.0
+httpx==0.27.0
 python-dotenv==1.0.0
 watchfiles==1.0.4
 
@@ -29,3 +30,6 @@ psutil==5.9.0
 # pydub==0.25.1
 # For better sentence splitting (potential future improvement)
 # nltk==3.8.1
+
+# Testing
+pytest-asyncio==0.23.5

--- a/Orpheus-FastAPI/tests/test_inference.py
+++ b/Orpheus-FastAPI/tests/test_inference.py
@@ -1,0 +1,127 @@
+import sys
+from pathlib import Path
+
+import pytest
+import httpx
+from unittest.mock import AsyncMock
+
+# Ensure the package path is available
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Stub sounddevice to avoid PortAudio dependency during tests
+import types
+fake_sd = types.SimpleNamespace(play=lambda *a, **k: None, wait=lambda *a, **k: None)
+sys.modules.setdefault("sounddevice", fake_sd)
+
+from tts_engine import inference
+
+
+@pytest.mark.asyncio
+async def test_generate_tokens_from_api_retries_on_timeout(monkeypatch):
+    """generate_tokens_from_api should retry on timeout and yield tokens."""
+    lines = [
+        'data: {"choices":[{"text":"hello"}]}',
+        'data: [DONE]'
+    ]
+
+    class FakeTimeoutStream:
+        async def __aenter__(self):
+            raise httpx.TimeoutException("timeout")
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    class FakeStream:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def aiter_lines(self):
+            for line in lines:
+                yield line
+
+        async def aread(self):
+            return b""
+
+    class FakeAsyncClient:
+        calls = 0
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def stream(self, *args, **kwargs):
+            FakeAsyncClient.calls += 1
+            if FakeAsyncClient.calls == 1:
+                return FakeTimeoutStream()
+            return FakeStream()
+
+    async def fake_sleep(_):
+        pass
+
+    monkeypatch.setattr(inference.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(inference.asyncio, "sleep", fake_sleep)
+
+    token_gen = inference.generate_tokens_from_api("hi")
+    tokens = [token async for token in token_gen]
+
+    assert tokens == ["hello>"]
+    assert FakeAsyncClient.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_speech_from_api_produces_audio(monkeypatch):
+    """generate_speech_from_api should return audio segments for short prompts."""
+
+    async def fake_generate_tokens_from_api(*_, **__):
+        for i in range(7):
+            yield f"tok{i}>"
+
+    def fake_turn_token_into_id(token, count):
+        return count + 1
+
+    def fake_convert_to_audio(multiframe, count):
+        return b"audio" + bytes([len(multiframe)])
+
+    monkeypatch.setattr(inference, "generate_tokens_from_api", fake_generate_tokens_from_api)
+    monkeypatch.setattr(inference, "turn_token_into_id", fake_turn_token_into_id)
+    monkeypatch.setattr(inference, "convert_to_audio", fake_convert_to_audio)
+
+    segments = await inference.generate_speech_from_api("hello world", use_batching=False)
+
+    assert len(segments) == 1
+    assert segments[0].startswith(b"audio")
+
+
+@pytest.mark.asyncio
+async def test_generate_speech_from_api_batches_long_text(monkeypatch):
+    """Long prompts should be split into batches and processed separately."""
+    prompts = []
+
+    def fake_generate_tokens_from_api(prompt, **kwargs):
+        prompts.append(prompt)
+
+        async def _gen():
+            for i in range(7):
+                yield f"{prompt}-{i}>"
+
+        return _gen()
+
+    mock_decoder = AsyncMock(return_value=[b"audio"])
+
+    monkeypatch.setattr(inference, "generate_tokens_from_api", fake_generate_tokens_from_api)
+    monkeypatch.setattr(inference, "tokens_decoder_sync", mock_decoder)
+
+    long_prompt = "First sentence. Second sentence. Third sentence."
+    await inference.generate_speech_from_api(long_prompt, use_batching=True, max_batch_chars=20)
+
+    assert mock_decoder.await_count == 2
+    assert prompts == ["First sentence. Second sentence.", "Third sentence."]

--- a/Orpheus-FastAPI/tts_engine/inference.py
+++ b/Orpheus-FastAPI/tts_engine/inference.py
@@ -1,6 +1,6 @@
 import os
 import sys
-import requests
+import httpx
 import json
 import time
 import wave
@@ -11,7 +11,7 @@ import threading
 import queue
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Dict, Any, Optional, Generator, Union, Tuple
+from typing import List, Dict, Any, Optional, Generator, Union, Tuple, AsyncGenerator
 from dotenv import load_dotenv
 
 # Helper to detect if running in Uvicorn's reloader
@@ -236,21 +236,26 @@ def format_prompt(prompt: str, voice: str = DEFAULT_VOICE) -> str:
     
     return f"{special_start}{formatted_prompt}{special_end}"
 
-def generate_tokens_from_api(prompt: str, voice: str = DEFAULT_VOICE, temperature: float = TEMPERATURE, 
-                           top_p: float = TOP_P, max_tokens: int = MAX_TOKENS, 
-                           repetition_penalty: float = REPETITION_PENALTY) -> Generator[str, None, None]:
+async def generate_tokens_from_api(
+    prompt: str,
+    voice: str = DEFAULT_VOICE,
+    temperature: float = TEMPERATURE,
+    top_p: float = TOP_P,
+    max_tokens: int = MAX_TOKENS,
+    repetition_penalty: float = REPETITION_PENALTY,
+) -> AsyncGenerator[str, None]:
     """Generate tokens from text using OpenAI-compatible API with optimized streaming and retry logic."""
     start_time = time.time()
     formatted_prompt = format_prompt(prompt, voice)
     print(f"Generating speech for: {formatted_prompt}")
-    
+
     # Optimize the token generation for GPUs
     if HIGH_END_GPU:
         # Use more aggressive parameters for faster generation on high-end GPUs
         print("Using optimized parameters for high-end GPU")
     elif torch.cuda.is_available():
         print("Using optimized parameters for GPU acceleration")
-    
+
     # Create the request payload (model field may not be required by some endpoints but included for compatibility)
     payload = {
         "prompt": formatted_prompt,
@@ -258,99 +263,96 @@ def generate_tokens_from_api(prompt: str, voice: str = DEFAULT_VOICE, temperatur
         "temperature": temperature,
         "top_p": top_p,
         "repeat_penalty": repetition_penalty,
-        "stream": True  # Always stream for better performance
+        "stream": True,  # Always stream for better performance
     }
-    
+
     # Add model field - this is ignored by many local inference servers for /v1/completions
     # but included for compatibility with OpenAI API and some servers that may use it
     model_name = os.environ.get("ORPHEUS_MODEL_NAME", "Orpheus-3b-FT-Q8_0.gguf")
     payload["model"] = model_name
-    
-    # Session for connection pooling and retry logic
-    session = requests.Session()
-    
+
     retry_count = 0
     max_retries = 3
-    
-    while retry_count < max_retries:
-        try:
-            # Make the API request with streaming and timeout
-            response = session.post(
-                API_URL, 
-                headers=HEADERS, 
-                json=payload, 
-                stream=True,
-                timeout=REQUEST_TIMEOUT
-            )
-            
-            if response.status_code != 200:
-                print(f"Error: API request failed with status code {response.status_code}")
-                print(f"Error details: {response.text}")
-                # Retry on server errors (5xx) but not on client errors (4xx)
-                if response.status_code >= 500:
-                    retry_count += 1
-                    wait_time = 2 ** retry_count  # Exponential backoff
-                    print(f"Retrying in {wait_time} seconds...")
-                    time.sleep(wait_time)
-                    continue
-                return
-            
-            # Process the streamed response with better buffering
-            buffer = ""
-            token_counter = 0
-            
-            # Iterate through the response to get tokens
-            for line in response.iter_lines():
-                if line:
-                    line_str = line.decode('utf-8')
-                    if line_str.startswith('data: '):
-                        data_str = line_str[6:]  # Remove the 'data: ' prefix
-                        
-                        if data_str.strip() == '[DONE]':
-                            break
-                            
-                        try:
-                            data = json.loads(data_str)
-                            if 'choices' in data and len(data['choices']) > 0:
-                                token_chunk = data['choices'][0].get('text', '')
-                                for token_text in token_chunk.split('>'):
-                                    token_text = f'{token_text}>'
-                                    token_counter += 1
-                                    perf_monitor.add_tokens()
 
-                                    if token_text:
-                                        yield token_text
-                        except json.JSONDecodeError as e:
-                            print(f"Error decoding JSON: {e}")
+    async with httpx.AsyncClient(timeout=REQUEST_TIMEOUT) as client:
+        while retry_count < max_retries:
+            try:
+                async with client.stream(
+                    "POST",
+                    API_URL,
+                    headers=HEADERS,
+                    json=payload,
+                ) as response:
+                    if response.status_code != 200:
+                        print(
+                            f"Error: API request failed with status code {response.status_code}"
+                        )
+                        print(f"Error details: {await response.aread()}")
+                        # Retry on server errors (5xx) but not on client errors (4xx)
+                        if response.status_code >= 500:
+                            retry_count += 1
+                            wait_time = 2 ** retry_count  # Exponential backoff
+                            print(f"Retrying in {wait_time} seconds...")
+                            await asyncio.sleep(wait_time)
                             continue
-            
-            # Generation completed successfully
-            generation_time = time.time() - start_time
-            tokens_per_second = token_counter / generation_time if generation_time > 0 else 0
-            print(f"Token generation complete: {token_counter} tokens in {generation_time:.2f}s ({tokens_per_second:.1f} tokens/sec)")
-            return
-            
-        except requests.exceptions.Timeout:
-            print(f"Request timed out after {REQUEST_TIMEOUT} seconds")
-            retry_count += 1
-            if retry_count < max_retries:
-                wait_time = 2 ** retry_count
-                print(f"Retrying in {wait_time} seconds... (attempt {retry_count+1}/{max_retries})")
-                time.sleep(wait_time)
-            else:
-                print("Max retries reached. Token generation failed.")
-                return
-                
-        except requests.exceptions.ConnectionError:
-            print(f"Connection error to API at {API_URL}")
-            retry_count += 1
-            if retry_count < max_retries:
-                wait_time = 2 ** retry_count
-                print(f"Retrying in {wait_time} seconds... (attempt {retry_count+1}/{max_retries})")
-                time.sleep(wait_time)
-            else:
-                print("Max retries reached. Token generation failed.")
-                return
+                        return
+
+                    token_counter = 0
+
+                    # Iterate through the response to get tokens
+                    async for line in response.aiter_lines():
+                        if line and line.startswith("data: "):
+                            data_str = line[6:]
+                            if data_str.strip() == "[DONE]":
+                                break
+                            try:
+                                data = json.loads(data_str)
+                                if "choices" in data and len(data["choices"]) > 0:
+                                    token_chunk = data["choices"][0].get("text", "")
+                                    for token_text in token_chunk.split(">"):
+                                        token_text = f"{token_text}>"
+                                        token_counter += 1
+                                        perf_monitor.add_tokens()
+                                        if token_text:
+                                            yield token_text
+                            except json.JSONDecodeError as e:
+                                print(f"Error decoding JSON: {e}")
+                                continue
+
+                    generation_time = time.time() - start_time
+                    tokens_per_second = (
+                        token_counter / generation_time if generation_time > 0 else 0
+                    )
+                    print(
+                        f"Token generation complete: {token_counter} tokens in {generation_time:.2f}s ({tokens_per_second:.1f} tokens/sec)"
+                    )
+                    return
+
+            except httpx.TimeoutException:
+                print(f"Request timed out after {REQUEST_TIMEOUT} seconds")
+                retry_count += 1
+                if retry_count < max_retries:
+                    wait_time = 2 ** retry_count
+                    print(
+                        f"Retrying in {wait_time} seconds... (attempt {retry_count+1}/{max_retries})"
+                    )
+                    await asyncio.sleep(wait_time)
+                else:
+                    print("Max retries reached. Token generation failed.")
+                    return
+
+            except httpx.RequestError:
+                print(f"Connection error to API at {API_URL}")
+                retry_count += 1
+                if retry_count < max_retries:
+                    wait_time = 2 ** retry_count
+                    print(
+                        f"Retrying in {wait_time} seconds... (attempt {retry_count+1}/{max_retries})"
+                    )
+                    await asyncio.sleep(wait_time)
+                else:
+                    print("Max retries reached. Token generation failed.")
+                    return
 
 # The turn_token_into_id function is now imported from speechpipe.py
 # This eliminates duplicate code and ensures consistent behavior
@@ -425,8 +427,8 @@ async def tokens_decoder(token_gen) -> Generator[bytes, None, None]:
                     if audio_samples is not None:
                         yield audio_samples
 
-def tokens_decoder_sync(syn_token_gen, output_file=None):
-    """Optimized synchronous wrapper with parallel processing and efficient file I/O."""
+async def tokens_decoder_sync(syn_token_gen, output_file=None):
+    """Optimized async wrapper with parallel processing and efficient file I/O."""
     # Use a larger queue for high-end systems
     queue_size = 100 if HIGH_END_GPU else 50
     audio_queue = queue.Queue(maxsize=queue_size)
@@ -452,13 +454,12 @@ def tokens_decoder_sync(syn_token_gen, output_file=None):
     # Convert the synchronous token generator into an async generator with batching
     async def async_token_gen():
         batch = []
-        for token in syn_token_gen:
+        async for token in syn_token_gen:
             batch.append(token)
             if len(batch) >= batch_size:
                 for t in batch:
                     yield t
                 batch = []
-        # Process any remaining tokens in the final batch
         for t in batch:
             yield t
 
@@ -512,7 +513,7 @@ def tokens_decoder_sync(syn_token_gen, output_file=None):
     # Wait for producer to actually start before proceeding
     # This avoids race conditions where we might try to read from an empty queue
     # before the producer has had a chance to add anything
-    producer_started_event.wait(timeout=5.0)
+    await asyncio.to_thread(producer_started_event.wait, 5.0)
     
     # Optimized I/O approach for all systems
     # This approach is simpler and more reliable than separate code paths
@@ -528,7 +529,7 @@ def tokens_decoder_sync(syn_token_gen, output_file=None):
         try:
             # Get the next audio chunk with a short timeout
             # This allows us to periodically check status and handle other events
-            audio = audio_queue.get(timeout=0.1)
+            audio = await asyncio.to_thread(audio_queue.get, timeout=0.1)
             
             # None marker indicates end of stream
             if audio is None:
@@ -544,7 +545,7 @@ def tokens_decoder_sync(syn_token_gen, output_file=None):
                 
                 # Flush buffer if it's large enough
                 if len(write_buffer) >= buffer_max_size:
-                    wav_file.writeframes(write_buffer)
+                    await asyncio.to_thread(wav_file.writeframes, write_buffer)
                     write_buffer = bytearray()  # Reset buffer
         
         except queue.Empty:
@@ -562,24 +563,24 @@ def tokens_decoder_sync(syn_token_gen, output_file=None):
                 
                 # Flush buffer periodically even if not full
                 if wav_file and len(write_buffer) > 0:
-                    wav_file.writeframes(write_buffer)
+                    await asyncio.to_thread(wav_file.writeframes, write_buffer)
                     write_buffer = bytearray()  # Reset buffer
     
     # Extra safety check - ensure thread is done
     if thread.is_alive():
         print("Waiting for token processor thread to complete...")
-        thread.join(timeout=10.0)
+        await asyncio.to_thread(thread.join, 10.0)
         if thread.is_alive():
             print("WARNING: Token processor thread did not complete within timeout")
     
     # Final flush of any remaining data
     if wav_file and len(write_buffer) > 0:
         print(f"Final buffer flush: {len(write_buffer)} bytes")
-        wav_file.writeframes(write_buffer)
+        await asyncio.to_thread(wav_file.writeframes, write_buffer)
     
     # Close WAV file if opened
     if wav_file:
-        wav_file.close()
+        await asyncio.to_thread(wav_file.close)
         if output_file:
             print(f"Audio saved to {output_file}")
     
@@ -669,8 +670,8 @@ def split_text_into_sentences(text):
     
     return combined_sentences
 
-def generate_speech_from_api(prompt, voice=DEFAULT_VOICE, output_file=None, temperature=TEMPERATURE, 
-                     top_p=TOP_P, max_tokens=MAX_TOKENS, repetition_penalty=None, 
+async def generate_speech_from_api(prompt, voice=DEFAULT_VOICE, output_file=None, temperature=TEMPERATURE,
+                     top_p=TOP_P, max_tokens=MAX_TOKENS, repetition_penalty=None,
                      use_batching=True, max_batch_chars=1000):
     """Generate speech from text using Orpheus model with performance optimizations."""
     print(f"Starting speech generation for '{prompt[:50]}{'...' if len(prompt) > 50 else ''}'")
@@ -686,9 +687,9 @@ def generate_speech_from_api(prompt, voice=DEFAULT_VOICE, output_file=None, temp
     if not use_batching or len(prompt) < max_batch_chars:
         # Note: we ignore any provided repetition_penalty and always use the hardcoded value
         # This ensures consistent quality regardless of what might be passed in
-        result = tokens_decoder_sync(
+        result = await tokens_decoder_sync(
             generate_tokens_from_api(
-                prompt=prompt, 
+                prompt=prompt,
                 voice=voice,
                 temperature=temperature,
                 top_p=top_p,
@@ -747,7 +748,7 @@ def generate_speech_from_api(prompt, voice=DEFAULT_VOICE, output_file=None, temp
             batch_temp_files.append(temp_output_file)
         
         # Generate speech for this batch
-        batch_segments = tokens_decoder_sync(
+        batch_segments = await tokens_decoder_sync(
             generate_tokens_from_api(
                 prompt=batch,
                 voice=voice,
@@ -914,16 +915,23 @@ def main():
     
     # Generate speech
     start_time = time.time()
-    audio_segments = generate_speech_from_api(
-        prompt=prompt,
-        voice=args.voice,
-        temperature=args.temperature,
-        top_p=args.top_p,
-        repetition_penalty=args.repetition_penalty,
-        output_file=output_file
-    )
+    try:
+        audio_segments = asyncio.run(
+            generate_speech_from_api(
+                prompt=prompt,
+                voice=args.voice,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                repetition_penalty=args.repetition_penalty,
+                output_file=output_file,
+            )
+        )
+    except Exception as e:
+        print(f"Error generating speech: {e}", file=sys.stderr)
+        sys.exit(1)
+
     end_time = time.time()
-    
+
     print(f"Speech generation completed in {end_time - start_time:.2f} seconds")
     print(f"Audio saved to {output_file}")
 

--- a/Orpheus-FastAPI/tts_engine/inference.py
+++ b/Orpheus-FastAPI/tts_engine/inference.py
@@ -11,7 +11,7 @@ import threading
 import queue
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from typing import List, Dict, Any, Optional, Generator, Union, Tuple, AsyncGenerator
+from typing import List, Dict, Any, Optional, Union, Tuple, AsyncGenerator
 from dotenv import load_dotenv
 
 # Helper to detect if running in Uvicorn's reloader
@@ -369,7 +369,7 @@ def convert_to_audio(multiframe: List[int], count: int) -> Optional[bytes]:
         
     return result
 
-async def tokens_decoder(token_gen) -> Generator[bytes, None, None]:
+async def tokens_decoder(token_gen) -> AsyncGenerator[bytes, None]:
     """Simplified token decoder with early first-chunk processing for lower latency."""
     buffer = []
     count = 0


### PR DESCRIPTION
## Summary
- switch token generation to `httpx.AsyncClient` with async streaming and retry backoff
- make token decoder and speech generation async, replacing blocking operations with asyncio helpers
- add `httpx` dependency for new async client
- cover async token streaming, batching, and audio synthesis with `pytest-asyncio` tests
- add `pytest-asyncio` dependency for async test support
- guard CLI entry point with try/except to report failures and exit non-zero

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c0ae81c80832caa2bb06618076563