### PR TITLE
Refactor TTS inference to async httpx streaming

### DIFF
--- a/Orpheus-FastAPI/requirements.txt
+++ b/Orpheus-FastAPI/requirements.txt
@@ -6,7 +6,7 @@ pydantic==2.3.0
 python-multipart==0.0.6
 
 # API and Communication
-requests==2.31.0
+httpx==0.28.1
 python-dotenv==1.0.0
 watchfiles==1.0.4
 


### PR DESCRIPTION
## Summary
- Switch token generation to async `httpx.AsyncClient` with streaming and retry logic
- Make speech generation and decoder wrappers fully async
- Replace `requests` with `httpx` dependency

## Testing
- `python -m py_compile Orpheus-FastAPI/tts_engine/inference.py Orpheus-FastAPI/tts_engine/speechpipe.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tts_engine')*

------
https://chatgpt.com/codex/tasks/task_e_689cb1ec99e4832c85a671182667e57d