### PR TITLE
Add PCM orchestrator module with adaptive chunking

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -1,0 +1,13 @@
+"""Orchestrator package coordinating PCM generation."""
+from .adapter import AudioChunk, TTSAdapter
+from .buffer import PlaybackBuffer
+from .chunk_ladder import ChunkLadder
+from .core import Orchestrator
+
+__all__ = [
+    "AudioChunk",
+    "TTSAdapter",
+    "PlaybackBuffer",
+    "ChunkLadder",
+    "Orchestrator",
+]

--- a/orchestrator/adapter.py
+++ b/orchestrator/adapter.py
@@ -1,0 +1,60 @@
+"""Adapter protocol for PCM generation.
+
+Defines the pull-based interface adapters must implement so that the
+orchestrator can request audio chunks as needed.  This keeps the hot
+path streaming-only and lets the orchestrator control chunk sizes.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Protocol
+
+
+@dataclass
+class AudioChunk:
+    """A unit of PCM audio returned by an adapter.
+
+    Attributes
+    ----------
+    pcm:
+        Raw PCM16 little-endian audio data.  The orchestrator treats this
+        as opaque bytes and writes it into the playback ring buffer.
+    duration_ms:
+        Duration of ``pcm`` in milliseconds.
+    markers:
+        Optional backend specific metadata (e.g. word boundaries).
+    eos:
+        End-of-stream marker.  When ``True`` the adapter has no further
+        audio for the current request.
+    """
+
+    pcm: bytes
+    duration_ms: float
+    markers: Optional[object] = None
+    eos: bool = False
+
+
+class TTSAdapter(Protocol):
+    """Protocol that all synthesis backends must satisfy.
+
+    The orchestrator drives synthesis by repeatedly calling ``pull`` with
+    a target chunk size.  Implementations must return as soon as a chunk
+    is ready; they may return smaller chunks than requested but must not
+    block waiting for an entire utterance.
+    """
+
+    async def pull(self, chunk_size: int) -> AudioChunk:
+        """Return the next chunk of audio.
+
+        Parameters
+        ----------
+        chunk_size:
+            Desired chunk granularity in adapter native units (tokens or
+            milliseconds).  Adapters may return less but should never
+            exceed this amount.
+        """
+        ...
+
+    async def reset(self) -> None:
+        """Reset any internal state after a barge-in event."""
+        ...

--- a/orchestrator/buffer.py
+++ b/orchestrator/buffer.py
@@ -1,0 +1,43 @@
+"""Playback buffer tracking utilities.
+
+The orchestrator treats playback as the clock and attempts to keep the
+buffer depth within a comfortable range.  This module provides a simple
+mutable object to track buffer occupancy in milliseconds.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+
+@dataclass
+class PlaybackBuffer:
+    """Tracks how much audio is queued for playback.
+
+    Parameters
+    ----------
+    capacity_ms:
+        Maximum desired buffer depth in milliseconds.  The buffer does
+        not enforce this strictly but exposes metrics for the
+        orchestrator's controller to act on.
+    """
+
+    capacity_ms: float
+    depth_ms: float = 0.0
+
+    def add(self, duration_ms: float) -> None:
+        """Record newly produced audio."""
+        self.depth_ms += duration_ms
+
+    def consume(self, duration_ms: float) -> None:
+        """Record that audio has been played back."""
+        self.depth_ms = max(0.0, self.depth_ms - duration_ms)
+
+    def reset(self) -> None:
+        """Flush the buffer, typically after a barge-in event."""
+        self.depth_ms = 0.0
+
+    def within(self, band: Tuple[float, float]) -> bool:
+        """Return ``True`` if current depth lies inside ``band``."""
+        low, high = band
+        return low <= self.depth_ms <= high

--- a/orchestrator/chunk_ladder.py
+++ b/orchestrator/chunk_ladder.py
@@ -1,0 +1,35 @@
+"""Discrete chunk-size ladder used by the adaptive rate controller."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+DEFAULT_LADDER: List[int] = [8, 12, 16, 24, 32, 48, 64]
+
+
+@dataclass
+class ChunkLadder:
+    """Manage step-wise chunk size selection.
+
+    The controller can step up or down the ladder in response to playback
+    buffer signals.  Ladder values are expressed in adapter native units
+    (tokens for text-based models or milliseconds for waveform models).
+    """
+
+    ladder: List[int] = field(default_factory=lambda: DEFAULT_LADDER.copy())
+    index: int = 0
+
+    @property
+    def current(self) -> int:
+        return self.ladder[self.index]
+
+    def step_up(self) -> None:
+        if self.index < len(self.ladder) - 1:
+            self.index += 1
+
+    def step_down(self) -> None:
+        if self.index > 0:
+            self.index -= 1
+
+    def reset(self) -> None:
+        self.index = 0

--- a/orchestrator/core.py
+++ b/orchestrator/core.py
@@ -1,0 +1,58 @@
+"""High-level PCM orchestrator.
+
+This module coordinates PCM generation by pulling from a TTS adapter,
+monitoring playback buffer levels and adapting chunk size accordingly.  It
+also exposes hooks for barge-in signalling so an external component can
+interrupt synthesis at a frame boundary.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncGenerator, Tuple
+
+from .adapter import AudioChunk, TTSAdapter
+from .buffer import PlaybackBuffer
+from .chunk_ladder import ChunkLadder
+
+
+class Orchestrator:
+    """Coordinate PCM generation and adaptive pacing."""
+
+    def __init__(
+        self,
+        adapter: TTSAdapter,
+        buffer: PlaybackBuffer,
+        ladder: ChunkLadder | None = None,
+        comfort_band: Tuple[float, float] = (50.0, 250.0),
+    ) -> None:
+        self.adapter = adapter
+        self.buffer = buffer
+        self.ladder = ladder or ChunkLadder()
+        self.comfort_band = comfort_band
+        self._barge_in = asyncio.Event()
+
+    def signal_barge_in(self) -> None:
+        """Notify the orchestrator that the current utterance was interrupted."""
+        self._barge_in.set()
+
+    async def stream(self) -> AsyncGenerator[AudioChunk, None]:
+        """Yield audio chunks until EOS or a barge-in occurs."""
+        while not self._barge_in.is_set():
+            chunk = await self.adapter.pull(self.ladder.current)
+            self.buffer.add(chunk.duration_ms)
+            yield chunk
+            if chunk.eos:
+                break
+            self._adapt_chunk_size()
+        if self._barge_in.is_set():
+            await self.adapter.reset()
+            self.buffer.reset()
+            self._barge_in.clear()
+
+    def _adapt_chunk_size(self) -> None:
+        """Adjust chunk size based on buffer depth."""
+        low, high = self.comfort_band
+        if self.buffer.depth_ms < low:
+            self.ladder.step_up()
+        elif self.buffer.depth_ms > high:
+            self.ladder.step_down()


### PR DESCRIPTION
## Summary
- add pull-based `TTSAdapter` protocol and `AudioChunk` dataclass
- introduce `PlaybackBuffer` and `ChunkLadder` helpers
- implement `Orchestrator` coordinating chunk requests, buffer depth and barge-in hooks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tts_engine')*
- `pip install tts_engine` *(fails: No matching distribution found for tts_engine)*

------
https://chatgpt.com/codex/tasks/task_e_689cb6bda7ec832ca28049120d2f646f