### PR TITLE
Add ring buffer and adaptive chunk ladder

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -3,11 +3,13 @@ from .adapter import AudioChunk, TTSAdapter
 from .buffer import PlaybackBuffer
 from .chunk_ladder import ChunkLadder
 from .core import Orchestrator
+from .ring_buffer import RingBuffer
 
 __all__ = [
     "AudioChunk",
     "TTSAdapter",
     "PlaybackBuffer",
     "ChunkLadder",
+    "RingBuffer",
     "Orchestrator",
 ]

--- a/orchestrator/chunk_ladder.py
+++ b/orchestrator/chunk_ladder.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Tuple
 
 DEFAULT_LADDER: List[int] = [8, 12, 16, 24, 32, 48, 64]
 
@@ -33,3 +33,16 @@ class ChunkLadder:
 
     def reset(self) -> None:
         self.index = 0
+
+    def adapt(self, depth_ms: float, band: Tuple[float, float]) -> None:
+        """Adjust ladder position based on ``depth_ms``.
+
+        ``band`` defines the low and high water marks of the playback
+        buffer.  If the buffer is shallow we step up to request larger
+        chunks; if it is too deep we step down to ease backpressure.
+        """
+        low, high = band
+        if depth_ms < low:
+            self.step_up()
+        elif depth_ms > high:
+            self.step_down()

--- a/orchestrator/core.py
+++ b/orchestrator/core.py
@@ -13,6 +13,7 @@ from typing import AsyncGenerator, Tuple
 from .adapter import AudioChunk, TTSAdapter
 from .buffer import PlaybackBuffer
 from .chunk_ladder import ChunkLadder
+from .ring_buffer import RingBuffer
 
 
 class Orchestrator:
@@ -24,11 +25,13 @@ class Orchestrator:
         buffer: PlaybackBuffer,
         ladder: ChunkLadder | None = None,
         comfort_band: Tuple[float, float] = (50.0, 250.0),
+        ring: RingBuffer | None = None,
     ) -> None:
         self.adapter = adapter
         self.buffer = buffer
         self.ladder = ladder or ChunkLadder()
         self.comfort_band = comfort_band
+        self.ring = ring
         self._barge_in = asyncio.Event()
 
     def signal_barge_in(self) -> None:
@@ -39,20 +42,17 @@ class Orchestrator:
         """Yield audio chunks until EOS or a barge-in occurs."""
         while not self._barge_in.is_set():
             chunk = await self.adapter.pull(self.ladder.current)
-            self.buffer.add(chunk.duration_ms)
+            if self.ring is not None:
+                self.ring.write(chunk.pcm)
+            else:
+                self.buffer.add(chunk.duration_ms)
             yield chunk
             if chunk.eos:
                 break
-            self._adapt_chunk_size()
+            self.ladder.adapt(self.buffer.depth_ms, self.comfort_band)
         if self._barge_in.is_set():
             await self.adapter.reset()
             self.buffer.reset()
+            if self.ring is not None:
+                self.ring.reset()
             self._barge_in.clear()
-
-    def _adapt_chunk_size(self) -> None:
-        """Adjust chunk size based on buffer depth."""
-        low, high = self.comfort_band
-        if self.buffer.depth_ms < low:
-            self.ladder.step_up()
-        elif self.buffer.depth_ms > high:
-            self.ladder.step_down()

--- a/orchestrator/ring_buffer.py
+++ b/orchestrator/ring_buffer.py
@@ -1,0 +1,83 @@
+"""Byte-oriented ring buffer for PCM streaming.
+
+The ring buffer stores raw PCM bytes and optionally updates a
+``PlaybackBuffer`` instance so the orchestrator can track how much audio
+is queued for playback.  Both write and read operations are expressed in
+bytes; the buffer converts between byte counts and milliseconds using a
+fixed sample rate of 16-bit mono PCM.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .buffer import PlaybackBuffer
+
+BYTES_PER_SAMPLE = 2  # PCM16 mono
+
+
+def _bytes_to_ms(n: int, sample_rate: int) -> float:
+    """Convert ``n`` PCM bytes to milliseconds."""
+    if sample_rate <= 0:
+        return 0.0
+    samples = n / BYTES_PER_SAMPLE
+    return samples / sample_rate * 1000.0
+
+
+@dataclass
+class RingBuffer:
+    """Simple circular buffer that tracks playback consumption."""
+
+    capacity: int
+    sample_rate: int
+    playback: Optional[PlaybackBuffer] = None
+
+    def __post_init__(self) -> None:
+        self._buf = bytearray(self.capacity)
+        self._read = 0
+        self._write = 0
+        self._size = 0
+
+    def __len__(self) -> int:
+        return self._size
+
+    def write(self, data: bytes) -> int:
+        """Append ``data`` to the buffer.
+
+        Returns the number of bytes written which may be less than the
+        length of ``data`` if the buffer is full.
+        """
+        if not data:
+            return 0
+        space = self.capacity - self._size
+        n = min(len(data), space)
+        first = min(n, self.capacity - self._write)
+        self._buf[self._write : self._write + first] = data[:first]
+        second = n - first
+        if second:
+            self._buf[0:second] = data[first:first + second]
+        self._write = (self._write + n) % self.capacity
+        self._size += n
+        if self.playback:
+            self.playback.add(_bytes_to_ms(n, self.sample_rate))
+        return n
+
+    def read(self, size: int) -> bytes:
+        """Remove and return up to ``size`` bytes from the buffer."""
+        if size <= 0 or self._size == 0:
+            return b""
+        n = min(size, self._size)
+        first = min(n, self.capacity - self._read)
+        data = bytes(self._buf[self._read : self._read + first])
+        second = n - first
+        if second:
+            data += bytes(self._buf[0:second])
+        self._read = (self._read + n) % self.capacity
+        self._size -= n
+        if self.playback:
+            self.playback.consume(_bytes_to_ms(n, self.sample_rate))
+        return data
+
+    def reset(self) -> None:
+        """Flush all buffered audio."""
+        self._read = self._write = self._size = 0


### PR DESCRIPTION
## Summary
- add PCM ring buffer that updates playback depth on writes and reads
- support buffer-aware chunk ladder adaptation to playback conditions
- wire orchestrator to ring buffer and reset on barge-in

## Testing
- `scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689cdffa600c832c8729f9ea890b855e