### PR TITLE
Add structured chunk logging and replay utility

### DIFF
--- a/orchestrator/core.py
+++ b/orchestrator/core.py
@@ -8,12 +8,19 @@ interrupt synthesis at a frame boundary.
 from __future__ import annotations
 
 import asyncio
+import base64
+import json
+import logging
+import time
 from typing import AsyncGenerator, Tuple
 
 from .adapter import AudioChunk, TTSAdapter
 from .buffer import PlaybackBuffer
 from .chunk_ladder import ChunkLadder
 from .ring_buffer import RingBuffer
+
+
+logger = logging.getLogger(__name__)
 
 
 class Orchestrator:
@@ -40,16 +47,33 @@ class Orchestrator:
 
     async def stream(self) -> AsyncGenerator[AudioChunk, None]:
         """Yield audio chunks until EOS or a barge-in occurs."""
+        chunk_id = 0
+        adapter_name = getattr(self.adapter, "name", self.adapter.__class__.__name__)
         while not self._barge_in.is_set():
-            chunk = await self.adapter.pull(self.ladder.current)
+            window = self.ladder.current
+            start = time.perf_counter()
+            chunk = await self.adapter.pull(window)
+            render_ms = (time.perf_counter() - start) * 1000.0
+
+            log_entry = {
+                "chunk_id": chunk_id,
+                "adapter": adapter_name,
+                "token_window": window,
+                "render_ms": render_ms,
+                "pcm": base64.b64encode(chunk.pcm).decode("ascii"),
+            }
+            logger.info(json.dumps(log_entry))
+
             if self.ring is not None:
                 self.ring.write(chunk.pcm)
             else:
                 self.buffer.add(chunk.duration_ms)
+
             yield chunk
             if chunk.eos:
                 break
             self.ladder.adapt(self.buffer.depth_ms, self.comfort_band)
+            chunk_id += 1
         if self._barge_in.is_set():
             await self.adapter.reset()
             self.buffer.reset()

--- a/replay.py
+++ b/replay.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Rebuild audio from orchestrator timeline logs."""
+
+import argparse
+import base64
+import json
+import wave
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Rebuild audio from timeline JSON logs")
+    parser.add_argument("log", help="Path to JSON lines timeline log")
+    parser.add_argument(
+        "-o", "--out", default="replay.wav", help="Destination WAV file"
+    )
+    parser.add_argument(
+        "--sample-rate", type=int, default=16000, help="PCM sample rate in Hz"
+    )
+    args = parser.parse_args()
+
+    pcm = bytearray()
+    with open(args.log, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            event = json.loads(line)
+            data = event.get("pcm")
+            if data:
+                pcm.extend(base64.b64decode(data))
+
+    with wave.open(args.out, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(args.sample_rate)
+        wf.writeframes(pcm)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log orchestrator chunks with `{chunk_id, adapter, token_window, render_ms}` and base64 PCM payloads
- add `replay.py` to reconstruct WAV audio from timeline JSON logs

## Testing
- `scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689ce4983b00832cb6ef0d5a88039a9f