### PR TITLE
Add scenario harness tests with timeline and audio artifacts

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 
+pythonpath = .

--- a/scenes/barge_in.py
+++ b/scenes/barge_in.py
@@ -1,0 +1,37 @@
+"""Barge-In scenario."""
+from orchestrator.adapter import AudioChunk, TTSAdapter
+
+from .utils import run_scene
+
+
+class BargeAdapter(TTSAdapter):
+    """Emit chunks until barge-in occurs."""
+
+    def __init__(self, total: int = 5) -> None:
+        self.total = total
+        self.sent = 0
+        self.reset_called = False
+
+    async def pull(self, _size):
+        if self.sent >= self.total:
+            return AudioChunk(pcm=b"", duration_ms=0, eos=True)
+        self.sent += 1
+        return AudioChunk(pcm=b"\x05\x00" * 160, duration_ms=10, eos=False)
+
+    async def reset(self):  # pragma: no cover - trivial
+        self.reset_called = True
+
+
+def run(tmp_path):
+    """Run Barge-In and record artifacts."""
+    adapter = BargeAdapter()
+    timeline_path, wav_path, timeline = run_scene("barge_in", adapter, tmp_path, barge_in_at=2)
+    return (
+        timeline_path,
+        wav_path,
+        {
+            "timeline": timeline,
+            "reset_called": adapter.reset_called,
+            "planned_chunks": adapter.total,
+        },
+    )

--- a/scenes/breathing_room.py
+++ b/scenes/breathing_room.py
@@ -1,0 +1,29 @@
+"""Breathing Room scenario."""
+from orchestrator.adapter import AudioChunk, TTSAdapter
+
+from .utils import run_scene
+
+
+class BreathingAdapter(TTSAdapter):
+    """Emit a couple of short chunks then EOS."""
+
+    def __init__(self) -> None:
+        self.chunks = [
+            AudioChunk(pcm=b"\x01\x00" * 160, duration_ms=10, eos=False),
+            AudioChunk(pcm=b"\x01\x00" * 160, duration_ms=10, eos=True),
+        ]
+
+    async def pull(self, _size):
+        if self.chunks:
+            return self.chunks.pop(0)
+        return AudioChunk(pcm=b"", duration_ms=0, eos=True)
+
+    async def reset(self):  # pragma: no cover - trivial
+        return None
+
+
+def run(tmp_path):
+    """Run Breathing Room and record artifacts."""
+    adapter = BreathingAdapter()
+    timeline_path, wav_path, timeline = run_scene("breathing_room", adapter, tmp_path)
+    return timeline_path, wav_path, {"timeline": timeline}

--- a/scenes/long_read.py
+++ b/scenes/long_read.py
@@ -1,0 +1,29 @@
+"""Long Read scenario."""
+from orchestrator.adapter import AudioChunk, TTSAdapter
+
+from .utils import run_scene
+
+
+class LongReadAdapter(TTSAdapter):
+    """Emit many uniform chunks to simulate a long narration."""
+
+    def __init__(self, total: int = 60) -> None:
+        self.total = total
+        self.sent = 0
+
+    async def pull(self, _size):
+        if self.sent >= self.total:
+            return AudioChunk(pcm=b"", duration_ms=0, eos=True)
+        self.sent += 1
+        eos = self.sent >= self.total
+        return AudioChunk(pcm=b"\x02\x00" * 160, duration_ms=10, eos=eos)
+
+    async def reset(self):  # pragma: no cover - trivial
+        return None
+
+
+def run(tmp_path):
+    """Run Long Read and record artifacts."""
+    adapter = LongReadAdapter()
+    timeline_path, wav_path, timeline = run_scene("long_read", adapter, tmp_path)
+    return timeline_path, wav_path, {"timeline": timeline}

--- a/scenes/mid_stream_swap.py
+++ b/scenes/mid_stream_swap.py
@@ -1,0 +1,34 @@
+"""Mid-Stream Swap scenario."""
+from orchestrator.adapter import AudioChunk, TTSAdapter
+
+from .utils import run_scene
+
+
+class SwapAdapter(TTSAdapter):
+    """Swap adapter identity mid-stream."""
+
+    def __init__(self, switch_after: int = 3, total: int = 6) -> None:
+        self.name = "adapter_a"
+        self.switch_after = switch_after
+        self.total = total
+        self.sent = 0
+
+    async def pull(self, _size):
+        if self.sent >= self.total:
+            return AudioChunk(pcm=b"", duration_ms=0, eos=True)
+        self.sent += 1
+        pcm = (b"\x03\x00" if self.name == "adapter_a" else b"\x04\x00") * 160
+        if self.sent == self.switch_after:
+            self.name = "adapter_b"
+        eos = self.sent >= self.total
+        return AudioChunk(pcm=pcm, duration_ms=10, eos=eos)
+
+    async def reset(self):  # pragma: no cover - trivial
+        return None
+
+
+def run(tmp_path):
+    """Run Mid-Stream Swap and record artifacts."""
+    adapter = SwapAdapter()
+    timeline_path, wav_path, timeline = run_scene("mid_stream_swap", adapter, tmp_path)
+    return timeline_path, wav_path, {"timeline": timeline}

--- a/scenes/utils.py
+++ b/scenes/utils.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+import time
+import wave
+from pathlib import Path
+
+from orchestrator.buffer import PlaybackBuffer
+from orchestrator.chunk_ladder import ChunkLadder
+from orchestrator.core import Orchestrator
+
+
+def run_scene(scene_name: str, adapter, tmp_path: Path, barge_in_at: int | None = None):
+    """Run a scene and capture timeline + WAV artifacts.
+
+    Parameters
+    ----------
+    scene_name: str
+        Name used for artifact files.
+    adapter: TTSAdapter
+        Adapter providing :class:`AudioChunk` instances.
+    tmp_path: Path
+        Directory to write artifacts into.
+    barge_in_at: int | None
+        If provided, signal a barge-in after this many chunks.
+    """
+    buffer = PlaybackBuffer(capacity_ms=1000)
+    orch = Orchestrator(adapter, buffer, ChunkLadder())
+    timeline: list[dict] = []
+    audio_bytes = bytearray()
+    start = time.perf_counter()
+
+    async def _run():
+        chunk_id = 0
+        async for chunk in orch.stream():
+            now = (time.perf_counter() - start) * 1000.0
+            audio_bytes.extend(chunk.pcm)
+            timeline.append(
+                {
+                    "chunk_id": chunk_id,
+                    "adapter": getattr(adapter, "name", adapter.__class__.__name__),
+                    "timestamp_ms": now,
+                    "duration_ms": chunk.duration_ms,
+                    "buffer_ms": buffer.depth_ms,
+                }
+            )
+            if barge_in_at is not None and chunk_id == barge_in_at:
+                orch.signal_barge_in()
+            chunk_id += 1
+
+    asyncio.run(_run())
+
+    wav_path = tmp_path / f"{scene_name}.wav"
+    with wave.open(str(wav_path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(16000)
+        wf.writeframes(audio_bytes)
+
+    timeline_path = tmp_path / f"{scene_name}.json"
+    with open(timeline_path, "w", encoding="utf-8") as fh:
+        json.dump(timeline, fh, indent=2)
+
+    return timeline_path, wav_path, timeline

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,0 +1,40 @@
+from scenes import barge_in, breathing_room, long_read, mid_stream_swap
+
+
+def test_breathing_room(tmp_path):
+    timeline_path, wav_path, info = breathing_room.run(tmp_path)
+    assert timeline_path.exists()
+    assert wav_path.exists()
+    timeline = info["timeline"]
+    assert len(timeline) >= 2
+    assert timeline[0]["chunk_id"] == 0
+
+
+def test_long_read(tmp_path):
+    timeline_path, wav_path, info = long_read.run(tmp_path)
+    assert timeline_path.exists()
+    assert wav_path.exists()
+    timeline = info["timeline"]
+    assert len(timeline) >= 50
+    durations = {t["duration_ms"] for t in timeline}
+    assert len(durations) == 1  # converged chunk size
+    assert all(t["buffer_ms"] >= 0 for t in timeline)
+
+
+def test_mid_stream_swap(tmp_path):
+    timeline_path, wav_path, info = mid_stream_swap.run(tmp_path)
+    assert timeline_path.exists()
+    assert wav_path.exists()
+    adapters = [t["adapter"] for t in info["timeline"]]
+    assert "adapter_a" in adapters and "adapter_b" in adapters
+    idx = adapters.index("adapter_b")
+    assert all(a == "adapter_a" for a in adapters[:idx])
+    assert all(a == "adapter_b" for a in adapters[idx:])
+
+
+def test_barge_in(tmp_path):
+    timeline_path, wav_path, info = barge_in.run(tmp_path)
+    assert timeline_path.exists()
+    assert wav_path.exists()
+    assert info["reset_called"]
+    assert len(info["timeline"]) < info["planned_chunks"]


### PR DESCRIPTION
## Summary
- add `scenes` package implementing Breathing Room, Long Read, Mid-Stream Swap, and Barge-In scenarios
- capture timeline JSON and WAV artifacts for each scene via new helper
- test scenario invariants and add project root to pytest path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce70698c4832c8648953afaba5481