### PR TITLE
Add timeline frame logging and replay utility

### DIFF
--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -8,6 +8,8 @@ def test_breathing_room(tmp_path):
     timeline = info["timeline"]
     assert len(timeline) >= 2
     assert timeline[0]["chunk_id"] == 0
+    assert "token_window" in timeline[0]
+    assert "render_ms" in timeline[0]
 
 
 def test_long_read(tmp_path):


### PR DESCRIPTION
## Summary
- expose optional `on_event` callback in `Orchestrator.stream` to log `{chunk_id, adapter, token_window, render_ms}` for each chunk
- record these fields in scene timelines and verify with tests
- add `replay.py` tool to rebuild audio from timeline logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d734c43f8832c8851a19f6704fa3c