### PR TITLE
feat: make scene tests emit artifacts

### DIFF
--- a/scenes/__init__.py
+++ b/scenes/__init__.py
@@ -1,0 +1,22 @@
+"""Scenario harness for open-ended streaming tests.
+
+This package exposes individual scene modules used by the test suite.  Each
+scene is responsible for driving a mock :class:`~orchestrator.adapter.TTSAdapter`
+and writing a timeline JSON alongside a WAV artifact so the results can be
+audited by humans and machines.
+
+Only a tiny shim lives here – the heavy lifting is done in the sibling modules
+(`barge_in`, `breathing_room`, `long_read` and `mid_stream_swap`).  Importing
+them at package level keeps ``from scenes import …`` working while remaining a
+light‑weight namespace.
+"""
+
+from . import barge_in, breathing_room, long_read, mid_stream_swap
+
+__all__ = [
+    "barge_in",
+    "breathing_room",
+    "long_read",
+    "mid_stream_swap",
+]
+

--- a/scenes/utils.py
+++ b/scenes/utils.py
@@ -1,3 +1,11 @@
+"""Helpers for running scenario scenes and capturing artifacts.
+
+`scenes` modules use these utilities to drive the orchestrator with a mock
+``TTSAdapter`` while collecting a timeline and WAV file for auditing.  The
+primary entry point is :func:`run_scene`, which executes a scene and writes the
+resulting artifacts to disk.
+"""
+
 import asyncio
 import json
 import time

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,8 +1,37 @@
+"""Open-ended scenario tests producing audit artefacts.
+
+If the environment variable ``SCENES_ARTIFACT_DIR`` is set, the generated
+timeline JSON and WAV files are written there so they can be collected by CI
+or inspected manually.  Otherwise they are created inside pytest's temporary
+directory like a normal unit test.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
 from scenes import barge_in, breathing_room, long_read, mid_stream_swap
 
 
-def test_breathing_room(tmp_path):
-    timeline_path, wav_path, info = breathing_room.run(tmp_path)
+@pytest.fixture
+def artifact_dir(tmp_path):
+    """Return output directory for scene artefacts.
+
+    The default is pytest's ``tmp_path`` but callers may override this by
+    setting ``SCENES_ARTIFACT_DIR`` in the environment.
+    """
+
+    base = os.environ.get("SCENES_ARTIFACT_DIR")
+    if base:
+        path = Path(base)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+    return tmp_path
+
+
+def test_breathing_room(artifact_dir):
+    timeline_path, wav_path, info = breathing_room.run(artifact_dir)
     assert timeline_path.exists()
     assert wav_path.exists()
     timeline = info["timeline"]
@@ -10,8 +39,8 @@ def test_breathing_room(tmp_path):
     assert timeline[0]["chunk_id"] == 0
 
 
-def test_long_read(tmp_path):
-    timeline_path, wav_path, info = long_read.run(tmp_path)
+def test_long_read(artifact_dir):
+    timeline_path, wav_path, info = long_read.run(artifact_dir)
     assert timeline_path.exists()
     assert wav_path.exists()
     timeline = info["timeline"]
@@ -21,8 +50,8 @@ def test_long_read(tmp_path):
     assert all(t["buffer_ms"] >= 0 for t in timeline)
 
 
-def test_mid_stream_swap(tmp_path):
-    timeline_path, wav_path, info = mid_stream_swap.run(tmp_path)
+def test_mid_stream_swap(artifact_dir):
+    timeline_path, wav_path, info = mid_stream_swap.run(artifact_dir)
     assert timeline_path.exists()
     assert wav_path.exists()
     adapters = [t["adapter"] for t in info["timeline"]]
@@ -32,8 +61,8 @@ def test_mid_stream_swap(tmp_path):
     assert all(a == "adapter_b" for a in adapters[idx:])
 
 
-def test_barge_in(tmp_path):
-    timeline_path, wav_path, info = barge_in.run(tmp_path)
+def test_barge_in(artifact_dir):
+    timeline_path, wav_path, info = barge_in.run(artifact_dir)
     assert timeline_path.exists()
     assert wav_path.exists()
     assert info["reset_called"]


### PR DESCRIPTION
## Summary
- expose scenario modules via `scenes` package
- allow scenario tests to persist WAV/timeline artifacts via `SCENES_ARTIFACT_DIR`
- document `scenes.utils` helper module for running scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d734f61f4832c9d0c8f26a4baaf5d