### PR TITLE
Add one click installer and startup scripts

### DIFF
--- a/requirements/full/cpu.txt
+++ b/requirements/full/cpu.txt
@@ -1,0 +1,2 @@
+fastapi==0.111.0
+uvicorn==0.30.1

--- a/requirements/full/gpu.txt
+++ b/requirements/full/gpu.txt
@@ -1,0 +1,3 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+torch==2.2.0

--- a/scripts/one_click.py
+++ b/scripts/one_click.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""One-click environment setup."""
+from __future__ import annotations
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+def miniforge_installed() -> bool:
+    return shutil.which("conda") is not None
+
+def detect_platform() -> tuple[str, str]:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "darwin":
+        os_name = "MacOSX"
+    elif system == "linux":
+        os_name = "Linux"
+    elif system == "windows":
+        os_name = "Windows"
+    else:
+        raise RuntimeError(f"Unsupported OS: {system}")
+    if machine in {"x86_64", "amd64"}:
+        arch = "x86_64"
+    elif machine in {"aarch64", "arm64"}:
+        arch = "arm64" if os_name == "MacOSX" else "aarch64"
+    else:
+        raise RuntimeError(f"Unsupported architecture: {machine}")
+    return os_name, arch
+
+def install_miniforge(os_name: str, arch: str) -> None:
+    ext = "exe" if os_name == "Windows" else "sh"
+    url = (
+        "https://github.com/conda-forge/miniforge/releases/latest/download/"
+        f"Miniforge3-{os_name}-{arch}.{ext}"
+    )
+    print(f"Downloading Miniforge from {url}")
+    with tempfile.TemporaryDirectory() as tmp:
+        installer = Path(tmp) / f"miniforge.{ext}"
+        urllib.request.urlretrieve(url, installer)
+        if os_name == "Windows":
+            target = Path.home() / "miniforge3"
+            subprocess.check_call([str(installer), "/S", f"/D={target}"])
+        else:
+            installer.chmod(0o755)
+            subprocess.check_call(["bash", str(installer), "-b"])
+    print("Miniforge installation complete")
+
+def detect_gpu() -> bool:
+    return shutil.which("nvidia-smi") is not None
+
+def pick_requirements() -> Path:
+    req_dir = Path(__file__).resolve().parent.parent / "requirements" / "full"
+    filename = "gpu.txt" if detect_gpu() else "cpu.txt"
+    return req_dir / filename
+
+def install_requirements(req_file: Path) -> None:
+    print(f"Installing dependencies from {req_file}")
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(req_file)])
+
+def main() -> None:
+    if not miniforge_installed():
+        os_name, arch = detect_platform()
+        install_miniforge(os_name, arch)
+    req_file = pick_requirements()
+    install_requirements(req_file)
+
+if __name__ == "__main__":
+    main()

--- a/start_linux.sh
+++ b/start_linux.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python scripts/one_click.py
+python -m uvicorn Orpheus-FastAPI.app:app

--- a/start_windows.bat
+++ b/start_windows.bat
@@ -1,0 +1,3 @@
+@echo off
+python scripts\one_click.py
+python -m uvicorn Orpheus-FastAPI.app:app


### PR DESCRIPTION
## Summary
- add `scripts/one_click.py` to install Miniforge and pick CPU/GPU requirements
- provide CPU and GPU requirement sets under `requirements/full`
- add `start_linux.sh` and `start_windows.bat` wrappers to launch `Orpheus-FastAPI.app:app`

## Testing
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689e33481b2c832cae5a15b8cf3f1d01