### PR TITLE
Add installation docs for Orpheus TTS integrations

### DIFF
--- a/ComfyUI/README.md
+++ b/ComfyUI/README.md
@@ -1,0 +1,15 @@
+# ComfyUI integration
+
+The `orpheus_tts` custom node depends on the `morpheus_tts` package.
+
+Install the dependency:
+
+```bash
+pip install -r custom_nodes/orpheus_tts/requirements.txt
+```
+
+If you prefer using the repository source directly, add the project root to `PYTHONPATH`:
+
+```bash
+export PYTHONPATH=/path/to/Project_Morpheus:$PYTHONPATH
+```

--- a/ComfyUI/custom_nodes/orpheus_tts/requirements.txt
+++ b/ComfyUI/custom_nodes/orpheus_tts/requirements.txt
@@ -1,0 +1,1 @@
+morpheus_tts

--- a/Oogabooga WebUI/README.md
+++ b/Oogabooga WebUI/README.md
@@ -74,6 +74,14 @@ If you ever need to install something manually in the `installer_files` environm
 
 </details>
 
+### Orpheus TTS extension
+
+Install the `morpheus_tts` dependency before enabling this extension:
+
+```bash
+pip install -r extensions/orpheus_tts/requirements.txt
+```
+
 <details>
 <summary>
 Manual portable installation with venv

--- a/Oogabooga WebUI/extensions/orpheus_tts/requirements.txt
+++ b/Oogabooga WebUI/extensions/orpheus_tts/requirements.txt
@@ -1,0 +1,1 @@
+morpheus_tts


### PR DESCRIPTION
## Summary
- add morpheus_tts dependency file for Oogabooga WebUI extension
- add morpheus_tts dependency file and README for ComfyUI custom node
- document Orpheus TTS setup steps in Oogabooga WebUI and ComfyUI READMEs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e4b43ec10832cb7bd1f377f32e0c8