### PR TITLE
Respect local SNAC path for speech engine

### DIFF
--- a/morpheus_tts/tts_engine/speechpipe.py
+++ b/morpheus_tts/tts_engine/speechpipe.py
@@ -35,7 +35,12 @@ try:
 except:
     pass
 
-model = SNAC.from_pretrained("hubertsiuzdak/snac_24khz").eval()
+# Allow overriding the SNAC model path via environment variable for offline use.
+# When ORPHEUS_SNAC_PATH is set, pass the path directly to `from_pretrained`.
+# Otherwise fall back to the default HuggingFace repository.
+snac_path = os.environ.get("ORPHEUS_SNAC_PATH")
+model_source = snac_path if snac_path else "hubertsiuzdak/snac_24khz"
+model = SNAC.from_pretrained(model_source).eval()
 
 # Check if CUDA is available and set device accordingly
 snac_device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"

--- a/tests/test_speechpipe_snac_path.py
+++ b/tests/test_speechpipe_snac_path.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _make_dummy_snac(called):
+    class DummySNAC:
+        @staticmethod
+        def from_pretrained(name):
+            called['name'] = name
+            return DummySNAC()
+
+        def eval(self):
+            return self
+
+        def to(self, device):
+            return self
+
+    dummy_module = types.ModuleType("snac")
+    dummy_module.SNAC = DummySNAC
+    return dummy_module
+
+
+def _load_speechpipe():
+    spec = importlib.util.spec_from_file_location(
+        "morpheus_tts.tts_engine.speechpipe",
+        Path(__file__).resolve().parents[1] / "morpheus_tts" / "tts_engine" / "speechpipe.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_snac_uses_env_path(monkeypatch, tmp_path):
+    called = {}
+    dummy_module = _make_dummy_snac(called)
+    monkeypatch.setitem(sys.modules, "snac", dummy_module)
+    dummy_path = tmp_path / "model"
+    dummy_path.mkdir()
+    monkeypatch.setenv("ORPHEUS_SNAC_PATH", str(dummy_path))
+
+    sys.modules.pop("morpheus_tts.tts_engine.speechpipe", None)
+    _load_speechpipe()
+
+    assert called["name"] == str(dummy_path)
+
+
+def test_snac_uses_default_repo(monkeypatch):
+    called = {}
+    dummy_module = _make_dummy_snac(called)
+    monkeypatch.setitem(sys.modules, "snac", dummy_module)
+    monkeypatch.delenv("ORPHEUS_SNAC_PATH", raising=False)
+
+    sys.modules.pop("morpheus_tts.tts_engine.speechpipe", None)
+    _load_speechpipe()
+
+    assert called["name"] == "hubertsiuzdak/snac_24khz"


### PR DESCRIPTION
## Summary
- Allow `ORPHEUS_SNAC_PATH` to override the SNAC model source, falling back to HuggingFace repo
- Add tests to ensure local path initialization works and default path is used when unset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689ef60afbac832cbf7055e2bb6fcb31