### PR TITLE
docs: document SNAC environment variables

### DIFF
--- a/Orpheus-FastAPI/.env
+++ b/Orpheus-FastAPI/.env
@@ -5,3 +5,16 @@ ORPHEUS_TEMPERATURE=0.8
 ORPHEUS_TOP_P=0.9
 ORPHEUS_HOST=0.0.0.0
 ORPHEUS_PORT=5005
+
+# Optional path to local SNAC model/voice directory. When set, HuggingFace
+# downloads are skipped and custom or finetuned voices can be used
+# ORPHEUS_SNAC_PATH=/path/to/snac
+
+# Number of transformer layers to offload to the GPU (default: 20)
+ORPHEUS_GPU_LAYERS=20
+
+# Number of CPU threads to dedicate to the SNAC engine (default: 8)
+ORPHEUS_CPU_THREADS=8
+
+# Default language code for voice selection (default: en)
+ORPHEUS_LANG=en

--- a/Orpheus-FastAPI/.env.example
+++ b/Orpheus-FastAPI/.env.example
@@ -17,3 +17,17 @@ ORPHEUS_MODEL_NAME=Orpheus-3b-FT-Q8_0.gguf # Model name sent to inference server
 # Web UI settings (keep in mind that the web UI is not secure and should not be exposed to the internet)
 ORPHEUS_PORT=5005
 ORPHEUS_HOST=0.0.0.0
+
+# SNAC runtime configuration
+# Local path to SNAC models/voices. Set this to bypass HuggingFace downloads
+# and enable custom or finetuned voices
+# ORPHEUS_SNAC_PATH=/path/to/snac
+
+# Number of transformer layers to offload to the GPU (default: 20)
+ORPHEUS_GPU_LAYERS=20
+
+# Number of CPU threads used by the SNAC engine (default: 8)
+ORPHEUS_CPU_THREADS=8
+
+# Default language code for voice selection (default: en)
+ORPHEUS_LANG=en

--- a/Orpheus-FastAPI/README.md
+++ b/Orpheus-FastAPI/README.md
@@ -406,6 +406,12 @@ Configure in docker compose, if using docker. Not using docker; create a `.env` 
 - `ORPHEUS_PORT`: Web server port (default: 5005)
 - `ORPHEUS_HOST`: Web server host (default: 0.0.0.0)
 - `ORPHEUS_MODEL_NAME`: Model name for inference server
+- `ORPHEUS_SNAC_PATH`: Local path to SNAC model and voice files. Providing a path
+  skips HuggingFace downloads and enables custom or finetuned voices
+- `ORPHEUS_GPU_LAYERS`: Number of transformer layers to offload to the GPU
+  (default: 20)
+- `ORPHEUS_CPU_THREADS`: Number of CPU threads used by the SNAC engine (default: 8)
+- `ORPHEUS_LANG`: Default language code for voice selection (default: `en`)
 
 The system now supports loading environment variables from a `.env` file in the project root, making it easier to configure without modifying system-wide environment settings. See `.env.example` for a template.
 

--- a/morpheus_tts/README.md
+++ b/morpheus_tts/README.md
@@ -39,3 +39,15 @@ asyncio.run(main())
 The REST endpoint returns a streaming WAV response.  The WebSocket endpoint
 first sends a WAV header followed by PCM frames.  Both methods yield raw bytes
 that can be written to a file or played back incrementally.
+
+## Environment Variables
+
+The server respects several environment variables for SNAC configuration:
+
+- `ORPHEUS_SNAC_PATH`: Local path to SNAC model and voice files. Setting this
+  skips HuggingFace downloads and enables custom or finetuned voices
+- `ORPHEUS_GPU_LAYERS`: Number of transformer layers to offload to the GPU
+  (default: 20)
+- `ORPHEUS_CPU_THREADS`: Number of CPU threads used by the SNAC engine
+  (default: 8)
+- `ORPHEUS_LANG`: Default language code for voice selection (default: `en`)


### PR DESCRIPTION
## Summary
- document ORPHEUS_SNAC_PATH, ORPHEUS_GPU_LAYERS, ORPHEUS_CPU_THREADS and ORPHEUS_LANG
- clarify that ORPHEUS_SNAC_PATH skips HF downloads and supports custom voices

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ef60bdc80832cbca69f388c3e9a33