### PR TITLE
Ensure Orpheus adapter respects chunk size

### DIFF
--- a/morpheus_tts/tts_engine/adapter.py
+++ b/morpheus_tts/tts_engine/adapter.py
@@ -1,58 +1,10 @@
-from __future__ import annotations
+"""Compatibility shim for the relocated Orpheus adapter.
 
-from typing import AsyncGenerator, Optional
+The concrete implementation lives in :mod:`orpheus_local`.  This module
+re-exports :class:`TTSAdapter` for any legacy imports using the old path.
+"""
 
-from ..orchestrator.adapter import AudioChunk, TTSAdapter as TTSAdapterProtocol
+from .orpheus_local import TTSAdapter
 
-from .inference import (
-    generate_speech_from_api,
-    SAMPLE_RATE,
-    DEFAULT_VOICE,
-)
+__all__ = ["TTSAdapter"]
 
-
-class TTSAdapter(TTSAdapterProtocol):
-    """Concrete adapter that wraps ``generate_speech_from_api``.
-
-    The adapter exposes the protocol expected by the orchestrator by
-    lazily initialising the underlying PCM generator on first use and
-    translating its output into :class:`AudioChunk` objects.
-    """
-
-    def __init__(
-        self,
-        prompt: str,
-        voice: str = DEFAULT_VOICE,
-        *,
-        use_batching: bool = False,
-        max_batch_chars: int = 1000,
-    ) -> None:
-        self.prompt = prompt
-        self.voice = voice
-        self.use_batching = use_batching
-        self.max_batch_chars = max_batch_chars
-        self._gen: Optional[AsyncGenerator[bytes, None]] = None
-
-    async def _ensure_gen(self) -> None:
-        if self._gen is None:
-            self._gen = await generate_speech_from_api(
-                prompt=self.prompt,
-                voice=self.voice,
-                use_batching=self.use_batching,
-                max_batch_chars=self.max_batch_chars,
-            )
-
-    async def pull(self, chunk_size: int) -> AudioChunk:  # chunk_size ignored for now
-        await self._ensure_gen()
-        assert self._gen is not None
-        try:
-            pcm = await self._gen.__anext__()
-        except StopAsyncIteration:
-            return AudioChunk(pcm=b"", duration_ms=0.0, eos=True)
-
-        duration_ms = len(pcm) / 2 / SAMPLE_RATE * 1000.0
-        return AudioChunk(pcm=pcm, duration_ms=duration_ms)
-
-    async def reset(self) -> None:
-        """Reset internal generator after a barge-in event."""
-        self._gen = None

--- a/morpheus_tts/tts_engine/orpheus_local.py
+++ b/morpheus_tts/tts_engine/orpheus_local.py
@@ -1,0 +1,97 @@
+"""Orpheus TTS adapter for local PCM streaming.
+
+This adapter wraps :func:`generate_speech_from_api` and translates its
+output into :class:`~morpheus_tts.orchestrator.adapter.AudioChunk`
+objects.  The underlying generator may yield PCM segments of arbitrary
+size, so we maintain an internal buffer and slice the data to honour the
+``chunk_size`` requested by the orchestrator.  ``chunk_size`` is
+expressed in milliseconds which is converted to a byte limit based on
+the configured sample rate.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncGenerator, Optional
+
+from ..orchestrator.adapter import (
+    AudioChunk,
+    TTSAdapter as TTSAdapterProtocol,
+)
+
+from .inference import (
+    generate_speech_from_api,
+    SAMPLE_RATE,
+    DEFAULT_VOICE,
+)
+
+
+class TTSAdapter(TTSAdapterProtocol):
+    """Concrete adapter that streams PCM audio from the Orpheus API."""
+
+    def __init__(
+        self,
+        prompt: str,
+        voice: str = DEFAULT_VOICE,
+        *,
+        use_batching: bool = False,
+        max_batch_chars: int = 1000,
+    ) -> None:
+        self.prompt = prompt
+        self.voice = voice
+        self.use_batching = use_batching
+        self.max_batch_chars = max_batch_chars
+        self._gen: Optional[AsyncGenerator[bytes, None]] = None
+        self._buffer = bytearray()
+        self._exhausted = False
+
+    async def _ensure_gen(self) -> None:
+        if self._gen is None and not self._exhausted:
+            self._gen = await generate_speech_from_api(
+                prompt=self.prompt,
+                voice=self.voice,
+                use_batching=self.use_batching,
+                max_batch_chars=self.max_batch_chars,
+            )
+
+    async def pull(self, chunk_size: int) -> AudioChunk:
+        """Return the next chunk of PCM audio.
+
+        Parameters
+        ----------
+        chunk_size:
+            Desired chunk duration in milliseconds.  The adapter slices
+            the PCM stream so that the returned ``AudioChunk`` never
+            exceeds this duration.
+        """
+
+        target_bytes = int(chunk_size / 1000 * SAMPLE_RATE * 2)
+
+        await self._ensure_gen()
+
+        while len(self._buffer) < target_bytes and not self._exhausted:
+            assert self._gen is not None
+            try:
+                self._buffer.extend(await self._gen.__anext__())
+            except StopAsyncIteration:
+                self._exhausted = True
+                break
+
+        if not self._buffer and self._exhausted:
+            return AudioChunk(pcm=b"", duration_ms=0.0, eos=True)
+
+        pcm = bytes(self._buffer[:target_bytes])
+        del self._buffer[:target_bytes]
+        duration_ms = len(pcm) / 2 / SAMPLE_RATE * 1000.0
+        eos = self._exhausted and len(self._buffer) == 0
+        return AudioChunk(pcm=pcm, duration_ms=duration_ms, eos=eos)
+
+    async def reset(self) -> None:
+        """Reset internal generator after a barge-in event."""
+
+        self._gen = None
+        self._buffer.clear()
+        self._exhausted = False
+
+
+__all__ = ["TTSAdapter"]
+

--- a/tests/test_tts_adapter_chunking.py
+++ b/tests/test_tts_adapter_chunking.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub out optional dependencies that require system libraries
+sys.modules.setdefault("sounddevice", types.SimpleNamespace())
+
+from morpheus_tts.tts_engine.orpheus_local import SAMPLE_RATE, TTSAdapter
+
+
+class DummyAdapter(TTSAdapter):
+    """TTSAdapter with a predictable PCM generator for testing."""
+
+    async def _ensure_gen(self) -> None:  # type: ignore[override]
+        if self._gen is None and not self._exhausted:
+            async def gen():
+                yield b"\x00" * 100
+
+            self._gen = gen()
+
+
+def test_pull_respects_chunk_size():
+    adapter = DummyAdapter(prompt="hi")
+    chunk_ms = 1
+    target_bytes = int(chunk_ms / 1000 * SAMPLE_RATE * 2)
+
+    async def run():
+        return [await adapter.pull(chunk_ms) for _ in range(3)]
+
+    first, second, third = asyncio.run(run())
+
+    assert len(first.pcm) == target_bytes
+    assert len(second.pcm) == target_bytes
+    assert len(third.pcm) == 100 - 2 * target_bytes
+    assert third.eos
+    assert all(len(c.pcm) <= target_bytes for c in (first, second))
+


### PR DESCRIPTION
## Summary
- implement buffered chunking in `orpheus_local` adapter so pulls never exceed requested duration
- expose new adapter via compatibility shim
- add regression test to verify chunk-size handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ef60eb510832c8e7eaf38e9acf422