### PR TITLE
chore: avoid uv auto-install in orpheus tts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 
 /Oogabooga WebUI/installer_files/env
 
+# Ignore virtual environments
+**/.venv/
+# Ignore Python cache directories
+**/__pycache__/

--- a/Orpheus-TTS/orpheus_tts_pypi/.no-auto-install
+++ b/Orpheus-TTS/orpheus_tts_pypi/.no-auto-install
@@ -1,0 +1,1 @@
+This directory is excluded from repo-wide auto-install scans to avoid triggering `uv`.


### PR DESCRIPTION
## Summary
- ignore virtual environments and Python caches in git
- add sentinel file to skip uv auto-install in `Orpheus-TTS/orpheus_tts_pypi`

## Testing
- `pip install -r requirements.txt`
- `scripts/run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a07b1c0554832cb13b4237af5a1a31