### PR TITLE
Install Orpheus dependencies before tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -3,5 +3,6 @@
 
 set -euo pipefail
 export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
+uv pip install --system -r Orpheus-TTS/orpheus_tts_pypi/pyproject.toml
 python -m pytest -q "$@"
 


### PR DESCRIPTION
## Summary
- Install Orpheus-TTS Python dependencies before running pytest

## Testing
- `./scripts/run_tests.sh` *(fails: requires large package downloads, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ed165094832c89beee4361ac9b8e