### PR TITLE
docs: document single-service architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,12 @@ Instead of brittle thresholds, give the agent **scenes** it must pass. Each scen
 
 Each scene produces a **timeline artifact** (JSON) and a **WAV**; a human can audition, and the CI can check coarse properties (continuous RMS, bounded zero-runs, monotonic timestamps).
 
+## Orpheus-FastAPI Single-Service
+
+- **Architecture:** The repo runs one FastAPI process that contains the orchestrator, adapter registry, streaming endpoints, and admin UI.
+- **Configuration:** Defaults load from `.env.example` and overrides from `.env` at the repo root. The `/config` and `/admin` surfaces mutate state and persist updates.
+- **Scene Expectations:** Add scenes under `SCENES/` verifying cold start, config reload via `/config`, and availability of `/stats`.
+
 ---
 
 # Deliverables for the coding agents (what to build)

--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -18,6 +18,17 @@
 - **Links:** <PRs, scenes, interface entries, goal names>
 
 _(New entries go on top. Keep each under ~20 lines.)_
+### [2025-09-01] single-service-architecture
+
+- **Context:** Prior repos split FastAPI, orchestrator, and admin surfaces; deployment required coordinating multiple services.
+- **Decision:** Consolidate into one FastAPI service (`Orpheus-FastAPI`) exposing `/stats`, `/config`, and `/admin` with `.env`-based configuration.
+- **Alternatives:** Maintain separate processes for TTS generation, control plane, and UI; shell scripts per component.
+- **Trade-offs:** Sacrifices modular scaling but simplifies local runs and scene coverage.
+- **Scope:** `Orpheus-FastAPI/app.py`, runtime config paths, admin endpoints.
+- **Impact:** Enables standalone orchestrator, admin interface, and direct inference integration.
+- **TTL / Review:** Revisit when horizontal scaling or process isolation is required.
+- **Status:** ACTIVE
+- **Links:** goals standalone-orchestrator, admin-interface, direct-inference-integration; interfaces /stats, /config, /admin
 ### [2025-08-18] decisions-log-canonical
 
 - **Context:** Repository contained `DECISIONS.md` while documentation referenced `DECISIONS.log`, causing inconsistency.

--- a/GOALS.md
+++ b/GOALS.md
@@ -84,3 +84,39 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** `codex-rs/cli/tests/login_status.rs`, `codex-rs/cli/tests/proto.rs`
 - **Linked Decisions:** [2025-08-30] cli-exitcode-refactor
 - **Notes:** facilitates test assertions on exit codes
+
+### Capability: standalone-orchestrator
+
+- **Purpose:** Provide a self-contained orchestrator service that streams audio via Orpheus-FastAPI.
+- **Scope:** `Orpheus-FastAPI/app.py`, adapter registry.
+- **Shape:** single FastAPI process coordinates adapters and exposes streaming endpoints.
+- **Compatibility:** configured through `.env` and `/config`; no migrations yet.
+- **Status:** planned
+- **Owner:** repo owner
+- **Linked Scenes:** TBD
+- **Linked Decisions:** [2025-09-01] single-service-architecture
+- **Notes:** n/a
+
+### Capability: admin-interface
+
+- **Purpose:** Offer operator-facing endpoints and UI for runtime control and observation.
+- **Scope:** `/admin`, `/stats`, config templates.
+- **Shape:** FastAPI surfaces expose status and allow configuration updates.
+- **Compatibility:** auth TBD; persists changes to `.env`.
+- **Status:** planned
+- **Owner:** repo owner
+- **Linked Scenes:** TBD
+- **Linked Decisions:** [2025-09-01] single-service-architecture
+- **Notes:** n/a
+
+### Capability: direct-inference-integration
+
+- **Purpose:** Connect directly to local inference backends without a separate service layer.
+- **Scope:** orchestrator adapters, config entries.
+- **Shape:** orchestrator calls inference libraries in-process with fallback to HTTP adapters.
+- **Compatibility:** selectable via `.env` or `/config`.
+- **Status:** planned
+- **Owner:** repo owner
+- **Linked Scenes:** TBD
+- **Linked Decisions:** [2025-09-01] single-service-architecture
+- **Notes:** n/a

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -50,3 +50,53 @@
 - **Change Log:**
   - 2025-08-19: return `Result` from helpers (#PR)
 
+### Surface: stats-endpoint
+- **Type:** API
+- **Purpose:** Expose runtime metrics for operators.
+- **Shape:**
+  - **Request/Input:** `GET /stats`
+  - **Response/Output:** `{uptime_ms, active_requests, adapters}`
+- **Idempotency/Retry:** read-only; safe to retry.
+- **Stability:** experimental
+- **Versioning:** none
+- **Auth/Access:** operator only
+- **Observability:** emits `stats_requested` event
+- **Failure Modes:** `503` when orchestrator not initialized
+- **Owner:** repo owner
+- **Code:** `Orpheus-FastAPI/app.py`
+- **Change Log:**
+  - 2025-09-01: documented endpoint
+
+### Surface: config-endpoint
+- **Type:** API
+- **Purpose:** Update active adapter or voice.
+- **Shape:**
+  - **Request/Input:** `POST /config` with `{adapter?, voice?}`
+  - **Response/Output:** `{adapter, voice}`
+- **Idempotency/Retry:** repeated calls override current state
+- **Stability:** experimental
+- **Versioning:** none
+- **Auth/Access:** operator only
+- **Observability:** emits `config_update` event
+- **Failure Modes:** `404` for unknown adapter
+- **Owner:** repo owner
+- **Code:** `Orpheus-FastAPI/app.py`
+- **Change Log:**
+  - 2025-09-01: documented endpoint
+
+### Surface: admin-endpoint
+- **Type:** API
+- **Purpose:** Serve administration UI and actions.
+- **Shape:**
+  - **Request/Input:** `GET /admin` (HTML), `POST /admin` actions
+  - **Response/Output:** HTML or `{status}`
+- **Idempotency/Retry:** `GET` is idempotent; actions may not be
+- **Stability:** experimental
+- **Versioning:** none
+- **Auth/Access:** operator only
+- **Observability:** access logged as `admin_access`
+- **Failure Modes:** `503` if service not ready
+- **Owner:** repo owner
+- **Code:** `Orpheus-FastAPI/app.py`
+- **Change Log:**
+  - 2025-09-01: documented endpoint


### PR DESCRIPTION
## WHY
Align repository docs with the single-service Orpheus-FastAPI architecture and expose new operator surfaces.

## OUTCOME
- AGENTS.md outlines single-service layout, config path, and scene expectations.
- GOALS.md tracks capabilities for standalone orchestrator, admin interface, and direct inference integration.
- DECISIONS.log records consolidation decision.
- INTERFACES.md documents `/stats`, `/config`, and `/admin` endpoints.

## SURFACES TOUCHED
- AGENTS.md
- GOALS.md
- DECISIONS.log
- INTERFACES.md

## EXIT VIA SCENES
- `pytest`

## COMPATIBILITY
No functional changes; documentation only.

## NO-GO
N/A


------
https://chatgpt.com/codex/tasks/task_e_68a3091df714832c8ca702075ae1fc11