### PR TITLE
feat: expose client voice and adapter endpoints

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -100,3 +100,13 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** revisit when configuration loading changes.
 - **Status:** active
 - **Links:** n/a
+### [2025-08-18] morpheus-client-endpoints
+- **Context:** Morpheus Client lacked introspection APIs for voices and adapters.
+- **Decision:** Add `/v1/audio/voices` and `/adapters` endpoints reusing Orpheus-FastAPI logic.
+- **Alternatives:** Rely solely on Orpheus-FastAPI for capability discovery.
+- **Trade-offs:** Duplicates minimal logic; adds another API surface to maintain.
+- **Scope:** `Morpheus_Client/api/server.py`, `INTERFACES.md`.
+- **Impact:** Clients can query available voices and adapter capabilities directly.
+- **TTL / Review:** revisit when services consolidate.
+- **Status:** active
+- **Links:** goal morpheus-client-introspection

--- a/GOALS.md
+++ b/GOALS.md
@@ -132,3 +132,14 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** TBD
 - **Linked Decisions:** [2025-09-02] central-config-module
 - **Notes:** n/a
+
+### Capability: morpheus-client-introspection
+- **Purpose:** Allow clients to discover available voices and adapter capabilities.
+- **Scope:** `Morpheus_Client/api/server.py`, `INTERFACES.md`
+- **Shape:** `GET /v1/audio/voices` → `{status, voices}`; `GET /adapters` → `{adapter_name: descriptor}`
+- **Compatibility:** read-only; no flags
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** n/a
+- **Linked Decisions:** morpheus-client-endpoints
+- **Notes:** none

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -100,3 +100,37 @@
 - **Code:** `Orpheus-FastAPI/app.py`
 - **Change Log:**
   - 2025-09-01: documented endpoint
+
+### Surface: client-voices-endpoint
+- **Type:** API
+- **Purpose:** List available synthesis voices.
+- **Shape:**
+  - **Request/Input:** `GET /v1/audio/voices`
+  - **Response/Output:** `{status, voices}`
+- **Idempotency/Retry:** read-only; safe to retry.
+- **Stability:** experimental
+- **Versioning:** none
+- **Auth/Access:** public
+- **Observability:** none
+- **Failure Modes:** `404` when no voices available
+- **Owner:** repo owner
+- **Code:** `Morpheus_Client/api/server.py`
+- **Change Log:**
+  - 2025-08-18: documented endpoint
+
+### Surface: client-adapters-endpoint
+- **Type:** API
+- **Purpose:** Expose capability descriptors for registered adapters.
+- **Shape:**
+  - **Request/Input:** `GET /adapters`
+  - **Response/Output:** `{adapter_name: descriptor}`
+- **Idempotency/Retry:** read-only; safe to retry.
+- **Stability:** experimental
+- **Versioning:** none
+- **Auth/Access:** public
+- **Observability:** none
+- **Failure Modes:** none
+- **Owner:** repo owner
+- **Code:** `Morpheus_Client/api/server.py`
+- **Change Log:**
+  - 2025-08-18: documented endpoint

--- a/Morpheus_Client/api/server.py
+++ b/Morpheus_Client/api/server.py
@@ -1,0 +1,28 @@
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+
+from Morpheus_Client.config import router as config_router, ensure_env_file_exists
+from morpheus_tts.tts_engine import AVAILABLE_VOICES
+from morpheus_tts.tts_engine.adapter_registry import registry as adapter_registry
+
+# Ensure environment variables are loaded from .env
+ensure_env_file_exists()
+load_dotenv(override=True)
+
+app = FastAPI()
+app.include_router(config_router)
+
+
+@app.get("/v1/audio/voices")
+async def list_voices():
+    """Return list of available voices."""
+    if not AVAILABLE_VOICES:
+        raise HTTPException(status_code=404, detail="No voices available")
+    return JSONResponse(content={"status": "ok", "voices": AVAILABLE_VOICES})
+
+
+@app.get("/adapters")
+async def get_adapters():
+    """Expose capability descriptors for all available adapters."""
+    return adapter_registry.available()


### PR DESCRIPTION
## Task
- **WHY:** Enable clients to discover available voices and adapters without hitting Orpheus-FastAPI.
- **OUTCOME:** `/v1/audio/voices` and `/adapters` endpoints in `Morpheus_Client` return `AVAILABLE_VOICES` and `adapter_registry.available()`.
- **SURFACES TOUCHED:** `Morpheus_Client/api/server.py`, `INTERFACES.md`, `GOALS.md`, `DECISIONS.log`
- **EXIT VIA SCENES:** `pytest`
- **COMPATIBILITY:** read-only endpoints; no breaking changes.
- **NO-GO:** failing tests.


------
https://chatgpt.com/codex/tasks/task_e_68a313aabf8c832ca4ff62ab45f1bcc7