### PR TITLE
feat: expose orchestrator timeline and stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 
 /Oogabooga WebUI/installer_files/env
 
+# Scene artifacts
+SCENES/_artifacts/
+
 # Ignore virtual environments
 **/.venv/
 # Ignore Python cache directories

--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -144,3 +144,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** review after first release.
 - **Status:** active
 - **Links:** goal morpheus-client-introspection
+
+### [2025-09-08] orchestrator-timeline
+
+- **Context:** Need visibility into orchestrator stages and live stats.
+- **Decision:** Emit `{stage,duration_ms,result}` events, persist to `SCENES/_artifacts/timeline.json`, and expose `/stats` API.
+- **Alternatives:** Rely solely on logging without structured timeline.
+- **Trade-offs:** In-memory event list may grow without bounds.
+- **Scope:** `Morpheus_Client/orchestrator/core.py`, `scenes/utils.py`, `Orpheus-FastAPI/app.py`.
+- **Impact:** Enables live monitoring and replayable transcripts.
+- **TTL / Review:** review after initial deployment.
+- **Status:** active
+- **Links:** goal streaming-telemetry

--- a/GOALS.md
+++ b/GOALS.md
@@ -38,6 +38,18 @@
 
 _(Append new capabilities below using the format above. Keep the list curated; collapse removed items to a brief tombstone if noisy.)_
 
+### Capability: streaming-telemetry
+
+- **Purpose:** Expose orchestrator runtime stages for live monitoring.
+- **Scope:** `Morpheus_Client/orchestrator`, `/stats` API, timeline artifacts.
+- **Shape:** `{stage, duration_ms, result}` events appended; `/stats` returns current timeline; artifacts saved to `SCENES/_artifacts`.
+- **Compatibility:** additive; resets on process restart.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `tests/test_scenes.py::test_breathing_room`
+- **Linked Decisions:** orchestrator-timeline
+- **Notes:** timeline growth is unbounded during run.
+
 ### Capability: graceful-missing-sandbox
 
 - **Purpose:** Ensure the CLI reports a clear error when the `codex-linux-sandbox` binary is absent.

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -151,3 +151,36 @@
 - **Code:** `Morpheus_Client/server.py`
 - **Change Log:**
   - 2025-09-02: mounted admin static assets
+
+### Surface: timeline-events
+- **Type:** Event
+- **Purpose:** Structured telemetry of orchestrator stages.
+- **Shape:**
+  - **Event:** `{stage: str, duration_ms: float, result: str}`
+- **Idempotency/Retry:** append-only; no retry.
+- **Stability:** experimental
+- **Versioning:** none
+- **Auth/Access:** internal
+- **Observability:** persisted to `SCENES/_artifacts/timeline.json`
+- **Failure Modes:** events lost if process crashes
+- **Owner:** repo owner
+- **Code:** `Morpheus_Client/orchestrator/core.py`
+- **Change Log:**
+  - 2025-09-08: initial schema
+
+### Surface: api-stats
+- **Type:** API
+- **Purpose:** Retrieve in-memory timeline for live monitoring.
+- **Shape:**
+  - **Request/Input:** `GET /stats`
+  - **Response/Output:** `{ "timeline": [<timeline-events>] }`
+- **Idempotency/Retry:** safe to retry
+- **Stability:** experimental
+- **Versioning:** none
+- **Auth/Access:** operator
+- **Observability:** emits timeline-events
+- **Failure Modes:** empty list if orchestrator idle
+- **Owner:** repo owner
+- **Code:** `Orpheus-FastAPI/app.py`
+- **Change Log:**
+  - 2025-09-08: endpoint added

--- a/Orpheus-FastAPI/app.py
+++ b/Orpheus-FastAPI/app.py
@@ -257,6 +257,13 @@ async def barge_in():
     return JSONResponse(content={"status": "ok"})
 
 
+@app.get("/stats")
+async def stats():
+    """Return the current orchestrator timeline for live monitoring."""
+    timeline = [] if current_orchestrator is None else current_orchestrator.timeline
+    return {"timeline": timeline}
+
+
 @app.websocket("/ws/barge-in")
 async def barge_in_ws(websocket: WebSocket):
     await websocket.accept()

--- a/scenes/utils.py
+++ b/scenes/utils.py
@@ -67,4 +67,8 @@ def run_scene(scene_name: str, adapter, tmp_path: Path, barge_in_at: int | None 
     with open(timeline_path, "w", encoding="utf-8") as fh:
         json.dump(timeline, fh, indent=2)
 
+    # Persist orchestrator timeline + metrics to canonical artifact path
+    artifact_path = Path("SCENES/_artifacts/timeline.json")
+    orch.save_timeline(artifact_path)
+
     return timeline_path, wav_path, timeline

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -7,6 +7,7 @@ directory like a normal unit test.
 """
 
 import os
+import json
 from pathlib import Path
 
 import pytest
@@ -39,6 +40,11 @@ def test_breathing_room(artifact_dir):
     assert timeline[0]["chunk_id"] == 0
     assert "token_window" in timeline[0]
     assert "render_ms" in timeline[0]
+    global_path = Path("SCENES/_artifacts/timeline.json")
+    assert global_path.exists()
+    with open(global_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert "events" in data and isinstance(data["events"], list)
 
 
 def test_long_read(artifact_dir):

--- a/tests/test_stats_endpoint.py
+++ b/tests/test_stats_endpoint.py
@@ -1,0 +1,61 @@
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+# Ensure repo root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Morpheus_Client.orchestrator.adapter import AudioChunk, TTSAdapter
+from Morpheus_Client.orchestrator.buffer import PlaybackBuffer
+from Morpheus_Client.orchestrator.chunk_ladder import ChunkLadder
+from Morpheus_Client.orchestrator.core import Orchestrator
+
+
+def load_app():
+    spec = importlib.util.spec_from_file_location(
+        "orfastapi_app", Path("Orpheus-FastAPI/app.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class DummyAdapter(TTSAdapter):
+    def __init__(self, chunks):
+        self.chunks = list(chunks)
+
+    async def pull(self, _size):
+        if self.chunks:
+            return self.chunks.pop(0)
+        return AudioChunk(pcm=b"", duration_ms=0, eos=True)
+
+    async def reset(self):
+        pass
+
+
+def test_stats_endpoint_exposes_timeline():
+    module = load_app()
+    adapter = DummyAdapter([AudioChunk(pcm=b"", duration_ms=10, eos=True)])
+    orch = Orchestrator(adapter, PlaybackBuffer(capacity_ms=500), ChunkLadder())
+    module.current_orchestrator = orch
+
+    async def run():
+        async for _ in orch.stream():
+            pass
+
+    asyncio.run(run())
+
+    async def fetch():
+        transport = httpx.ASGITransport(app=module.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.get("/stats")
+
+    resp = asyncio.run(fetch())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "timeline" in body
+    assert isinstance(body["timeline"], list)


### PR DESCRIPTION
### Summary
- orchestrator records `{stage,duration_ms,result}` events and can persist metrics to `SCENES/_artifacts/timeline.json`
- `/stats` endpoint exposes the in-memory timeline for live monitoring
- document event schema and stats API in `INTERFACES.md`

### Testing
- `pytest`

### Task
- **WHY:** enable live monitoring and replayable transcripts from the orchestrator.
- **OUTCOME:** timeline events persisted and stats available via API.
- **SURFACES TOUCHED:** `Morpheus_Client/orchestrator/core.py`, `scenes/utils.py`, `Orpheus-FastAPI/app.py`, `INTERFACES.md`.
- **EXIT VIA SCENES:** `tests/test_scenes.py::test_breathing_room`, `tests/test_stats_endpoint.py::test_stats_endpoint_exposes_timeline`, `tests/test_orchestrator.py::test_timeline_records_events`.
- **COMPATIBILITY:** additive feature; timeline resets on restart.
- **NO-GO:** merge blocked if scenes fail.


------
https://chatgpt.com/codex/tasks/task_e_68a3759d584c832c9c41abd4723c6b22