### PR TITLE
Add pluggable text sources and config

### DIFF
--- a/ADAPTERS.md
+++ b/ADAPTERS.md
@@ -19,4 +19,34 @@
   "limits": {"max_batch": 1000, "timeout_ms": 30000},
   "stateful_context": "rolling|minimal|none"
 }
+```
 
+## Text Source Adapters
+
+Text sources implement the `TextSource` protocol and expose a descriptor for runtime negotiation.
+
+### Protocol
+
+```python
+class TextSource(Protocol):
+    async def stream(self) -> AsyncGenerator[str, None]:
+        ...
+```
+
+### Descriptor
+
+```json
+{
+  "name": "websocket|http_poll|cli_pipe",
+  "streaming": true,
+  "unit": "msgs",
+  "granularity": ["line"],
+  "stateful_context": "rolling|minimal|none"
+}
+```
+
+Bundled adapters:
+
+- `websocket` – reads messages from a WebSocket feed.
+- `http_poll` – polls an HTTP endpoint for new text.
+- `cli_pipe` – consumes lines from a CLI pipe via `asyncio`.

--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -144,3 +144,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** review after first release.
 - **Status:** active
 - **Links:** goal morpheus-client-introspection
+
+### [2025-09-14] text-source-adapters
+
+- **Context:** Need to ingest text from multiple origins for synthesis.
+- **Decision:** Introduce `TextSource` protocol with adapters for WebSocket, HTTP polling and CLI pipes.
+- **Alternatives:** Hardcode a single input mechanism.
+- **Trade-offs:** Additional registry and configuration surface.
+- **Scope:** `text_sources/*`, `Morpheus_Client/server.py`, `ADAPTERS.md`, `INTERFACES.md`.
+- **Impact:** Text sources are pluggable and selectable via `/config`.
+- **TTL / Review:** revisit when more sources are required.
+- **Status:** active
+- **Links:** goal pluggable-text-sources

--- a/GOALS.md
+++ b/GOALS.md
@@ -143,3 +143,15 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** n/a
 - **Linked Decisions:** morpheus-client-endpoints
 - **Notes:** none
+
+### Capability: pluggable-text-sources
+
+- **Purpose:** Consume text from interchangeable sources like WebSocket feeds or CLI pipes.
+- **Scope:** `text_sources/*`, `Morpheus_Client/server.py`, `/config` endpoint.
+- **Shape:** sources implement `TextSource` protocol and can be hot-swapped via config.
+- **Compatibility:** selectable via `/config`; no migrations.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** TBD
+- **Linked Decisions:** [2025-09-14] text-source-adapters
+- **Notes:** initial adapters for WebSocket, HTTP polling and CLI pipe.

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -69,20 +69,21 @@
 
 ### Surface: config-endpoint
 - **Type:** API
-- **Purpose:** Update active adapter or voice.
+- **Purpose:** Update active adapter, voice or text source.
 - **Shape:**
-  - **Request/Input:** `POST /config` with `{adapter?, voice?}`
-  - **Response/Output:** `{adapter, voice}`
+  - **Request/Input:** `POST /config` with `{adapter?, voice?, source?}`
+  - **Response/Output:** `{adapter, voice, source}`
 - **Idempotency/Retry:** repeated calls override current state
 - **Stability:** experimental
 - **Versioning:** none
 - **Auth/Access:** operator only
 - **Observability:** emits `config_update` event
-- **Failure Modes:** `404` for unknown adapter
+- **Failure Modes:** `404` for unknown adapter or source
 - **Owner:** repo owner
-- **Code:** `Orpheus-FastAPI/app.py`
+- **Code:** `Morpheus_Client/server.py`
 - **Change Log:**
   - 2025-09-01: documented endpoint
+  - 2025-09-14: added text source configuration
 
 ### Surface: admin-endpoint
 - **Type:** API
@@ -134,6 +135,23 @@
 - **Code:** `Morpheus_Client/server.py`
 - **Change Log:**
   - 2025-08-18: documented endpoint
+
+### Surface: client-sources-endpoint
+- **Type:** API
+- **Purpose:** Expose capability descriptors for text sources.
+- **Shape:**
+  - **Request/Input:** `GET /sources`
+  - **Response/Output:** `{source_name: descriptor}`
+- **Idempotency/Retry:** read-only; safe to retry.
+- **Stability:** experimental
+- **Versioning:** none
+- **Auth/Access:** public
+- **Observability:** none
+- **Failure Modes:** none
+- **Owner:** repo owner
+- **Code:** `Morpheus_Client/server.py`
+- **Change Log:**
+  - 2025-09-14: documented endpoint
 
 ### Surface: client-admin-static
 - **Type:** Static

--- a/tests/test_text_sources.py
+++ b/tests/test_text_sources.py
@@ -1,0 +1,82 @@
+import asyncio
+import os
+import asyncio
+import os
+import sys
+import types
+
+import httpx
+import websockets
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.modules.setdefault("sounddevice", types.SimpleNamespace())
+
+from text_sources.cli_pipe import CLIPipeSource
+from text_sources.http_poll import HTTPPollingSource
+from text_sources.websocket import WebSocketSource
+from Morpheus_Client.server import app
+
+
+def test_cli_pipe_source():
+    async def run():
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"hello\nworld\n")
+        reader.feed_eof()
+        source = CLIPipeSource(reader)
+        out = []
+        async for msg in source.stream():
+            out.append(msg)
+        return out
+
+    assert asyncio.run(run()) == ["hello", "world"]
+
+
+def test_http_poll_source():
+    messages = ["first", "second"]
+
+    def handler(request):
+        if messages:
+            return httpx.Response(200, text=messages.pop(0))
+        return httpx.Response(200, text="")
+
+    transport = httpx.MockTransport(handler)
+    client = httpx.AsyncClient(transport=transport)
+    source = HTTPPollingSource("http://test", client=client)
+
+    async def run():
+        out = []
+        async for msg in source.stream():
+            out.append(msg)
+        return out
+
+    assert asyncio.run(run()) == ["first", "second"]
+
+
+def test_websocket_source():
+    async def run():
+        async def ws_handler(websocket):
+            await websocket.send("one")
+            await websocket.send("two")
+            await websocket.close()
+
+        async with websockets.serve(ws_handler, "localhost", 0) as server:
+            port = server.sockets[0].getsockname()[1]
+            source = WebSocketSource(f"ws://localhost:{port}")
+            out = []
+            async for msg in source.stream():
+                out.append(msg)
+        return out
+
+    assert asyncio.run(run()) == ["one", "two"]
+
+
+def test_config_updates_source():
+    async def run():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.post("/config", json={"source": "cli_pipe"})
+            return resp
+
+    resp = asyncio.run(run())
+    assert resp.status_code == 200
+    assert resp.json()["source"] == "cli_pipe"

--- a/text_sources/__init__.py
+++ b/text_sources/__init__.py
@@ -1,0 +1,22 @@
+"""Pluggable text source interfaces.
+
+Defines the :class:`TextSource` protocol used to obtain chunks of
+text from different origins such as WebSocket feeds, HTTP polling or
+local CLI pipes.  Adapters implementing this protocol are registered
+with :mod:`text_sources.registry`.
+"""
+from __future__ import annotations
+
+from typing import AsyncGenerator, Protocol
+
+
+class TextSource(Protocol):
+    """Protocol that all text source adapters must satisfy.
+
+    Implementations yield chunks of text on demand.  The orchestrator
+    or host service consumes the async generator to receive new text.
+    """
+
+    async def stream(self) -> AsyncGenerator[str, None]:
+        """Yield text chunks until the source is exhausted."""
+        ...

--- a/text_sources/cli_pipe.py
+++ b/text_sources/cli_pipe.py
@@ -1,0 +1,31 @@
+"""Text source adapter reading from a CLI pipe."""
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncGenerator, Dict, Any
+
+from . import TextSource
+
+
+class CLIPipeSource(TextSource):
+    """Yield lines from an ``asyncio`` ``StreamReader``."""
+
+    def __init__(self, reader: asyncio.StreamReader) -> None:
+        self.reader = reader
+
+    async def stream(self) -> AsyncGenerator[str, None]:
+        while True:
+            line = await self.reader.readline()
+            if not line:
+                break
+            yield line.decode().rstrip("\n")
+
+
+def describe() -> Dict[str, Any]:
+    return {
+        "name": "cli_pipe",
+        "streaming": True,
+        "unit": "msgs",
+        "granularity": ["line"],
+        "stateful_context": "none",
+    }

--- a/text_sources/http_poll.py
+++ b/text_sources/http_poll.py
@@ -1,0 +1,35 @@
+"""Text source adapter that polls an HTTP endpoint."""
+from __future__ import annotations
+
+from typing import AsyncGenerator, Dict, Any
+
+import httpx
+
+from . import TextSource
+
+
+class HTTPPollingSource(TextSource):
+    """Retrieve text by repeatedly GETting an HTTP endpoint."""
+
+    def __init__(self, url: str, client: httpx.AsyncClient | None = None) -> None:
+        self.url = url
+        self._client = client or httpx.AsyncClient()
+
+    async def stream(self) -> AsyncGenerator[str, None]:
+        async with self._client as client:
+            while True:
+                resp = await client.get(self.url)
+                text = resp.text.strip()
+                if not text:
+                    break
+                yield text
+
+
+def describe() -> Dict[str, Any]:
+    return {
+        "name": "http_poll",
+        "streaming": False,
+        "unit": "msgs",
+        "granularity": ["line"],
+        "stateful_context": "none",
+    }

--- a/text_sources/registry.py
+++ b/text_sources/registry.py
@@ -1,0 +1,49 @@
+"""Registry for text source adapters."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Type
+
+from . import TextSource
+
+
+@dataclass
+class _SourceSpec:
+    constructor: Type[TextSource]
+    describe: Callable[[], Dict[str, Any]]
+
+
+class SourceRegistry:
+    """Simple registry for text sources."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, _SourceSpec] = {}
+
+    def register(
+        self, name: str, constructor: Type[TextSource], describe: Callable[[], Dict[str, Any]]
+    ) -> None:
+        self._registry[name] = _SourceSpec(constructor, describe)
+
+    def available(self) -> Dict[str, Dict[str, Any]]:
+        """Return capability descriptors for all registered sources."""
+
+        return {name: spec.describe() for name, spec in self._registry.items()}
+
+    def create(self, name: str, **kwargs: Any) -> TextSource:
+        """Instantiate a source by name."""
+
+        spec = self._registry[name]
+        return spec.constructor(**kwargs)
+
+
+from .websocket import WebSocketSource, describe as ws_describe
+from .http_poll import HTTPPollingSource, describe as http_describe
+from .cli_pipe import CLIPipeSource, describe as cli_describe
+
+# Global registry instance pre-populated with the built-in sources
+registry = SourceRegistry()
+registry.register("websocket", WebSocketSource, ws_describe)
+registry.register("http_poll", HTTPPollingSource, http_describe)
+registry.register("cli_pipe", CLIPipeSource, cli_describe)
+
+__all__ = ["registry", "SourceRegistry"]

--- a/text_sources/websocket.py
+++ b/text_sources/websocket.py
@@ -1,0 +1,30 @@
+"""Text source adapter reading from a WebSocket feed."""
+from __future__ import annotations
+
+from typing import AsyncGenerator, Dict, Any
+
+import websockets
+
+from . import TextSource
+
+
+class WebSocketSource(TextSource):
+    """Receive text messages from a WebSocket server."""
+
+    def __init__(self, uri: str) -> None:
+        self.uri = uri
+
+    async def stream(self) -> AsyncGenerator[str, None]:
+        async with websockets.connect(self.uri) as ws:
+            async for message in ws:
+                yield message
+
+
+def describe() -> Dict[str, Any]:
+    return {
+        "name": "websocket",
+        "streaming": True,
+        "unit": "msgs",
+        "granularity": ["line"],
+        "stateful_context": "rolling",
+    }


### PR DESCRIPTION
## WHY
Enable ingestion of text from WebSocket feeds, HTTP polling, or CLI pipes.

## OUTCOME
Text sources implement a common interface and can be selected via `/config`.

## SURFACES TOUCHED
- `text_sources/*`
- `Morpheus_Client/server.py` (`/sources`, `/config`)
- `ADAPTERS.md`
- `INTERFACES.md`
- `GOALS.md`
- `DECISIONS.log`
- `tests/test_text_sources.py`

## EXIT VIA SCENES
- `pytest tests/test_text_sources.py`
- `pytest`

## COMPATIBILITY
Selectable via `/config`; no migrations needed.

## NO-GO
Abort if `/config` returns `404` for unknown source.


------
https://chatgpt.com/codex/tasks/task_e_68a37585561c832cb05c27c4897dc363