### PR TITLE
Add Orpheus C++ binding requirement and startup check

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -18,6 +18,17 @@
 - **Links:** <PRs, scenes, interface entries, goal names>
 
 _(New entries go on top. Keep each under ~20 lines.)_
+### [2025-09-30] orpheus-cpp-required
+
+- **Context:** Starting the service without `orpheus_cpp` led to runtime failures during synthesis.
+- **Decision:** Pin `orpheus-cpp` and abort startup with a descriptive error when the module is missing.
+- **Alternatives:** Import on first use and fail lazily; rely on an external service for synthesis.
+- **Trade-offs:** Adds a native build step that increases installation time.
+- **Scope:** `requirements.txt`, `scripts/start.py`, `README.md`.
+- **Impact:** Predictable startup behaviour and clearer dependency expectations.
+- **TTL / Review:** Revisit if a pure-Python or remote backend becomes default.
+- **Status:** ACTIVE
+- **Links:** goal orpheus-cpp-startup-check, tests/test_start_requires_orpheus_cpp.py
 ### [2025-09-21] fastapi-migration
 
 - **Context:** Docs and configs still referenced FastAPI though the service now runs on a lightweight ASGI stack.

--- a/GOALS.md
+++ b/GOALS.md
@@ -192,3 +192,15 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** TBD
 - **Linked Decisions:** [2025-09-19] start-entrypoint
 - **Notes:** none
+
+### Capability: orpheus-cpp-startup-check
+
+- **Purpose:** Fail fast when the local C++ bindings are missing.
+- **Scope:** `scripts/start.py`, `requirements.txt`, `README.md`.
+- **Shape:** Startup aborts with a descriptive error if `orpheus_cpp` cannot be imported.
+- **Compatibility:** additive; service does not launch without the binding.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `tests/test_start_requires_orpheus_cpp.py`
+- **Linked Decisions:** [2025-09-30] orpheus-cpp-required
+- **Notes:** build step may take several minutes

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ pip install -r requirements.txt
   pip install torch==2.2.0
   ```
 
+### C++ bindings
+The local streaming adapter uses `orpheus_cpp`, which builds a native extension. Ensure a C++17 toolchain and CMake are available (e.g. `sudo apt install build-essential cmake` on Linux or [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) on Windows) before installing:
+
+```bash
+pip install orpheus-cpp
+```
+
+This dependency is pinned in `requirements.txt`; the build step may take several minutes.
+
 ### UI build
 To build the optional web UI, install Node.js and npm then run within the UI directory (for example `Morpheus_Client/admin`):
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ httpx==0.28.1
 jinja2==3.1.6
 markdown==3.6
 numpy==2.2.6
+orpheus-cpp==0.0.3
 pandas==2.2.2
 peft==0.16.0
 Pillow==10.4.0

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -7,6 +7,12 @@ from Morpheus_Client import start_server
 
 def main() -> None:
     """Entry point to launch the Morpheus server and open admin UI."""
+    try:
+        import orpheus_cpp  # noqa: F401
+    except ImportError as exc:  # pragma: no cover - depends on optional dep
+        raise SystemExit(
+            "orpheus_cpp is required for local synthesis. Install it with `pip install orpheus-cpp`."
+        ) from exc
     ensure_env_file_exists()
     # Load default .env if present
     load_dotenv(override=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import sys
+import types
+
+# Provide lightweight stubs for optional native dependencies
+sys.modules.setdefault("sounddevice", types.SimpleNamespace())
+
+class _Torch(types.SimpleNamespace):
+    def __init__(self):
+        cuda = types.SimpleNamespace(is_available=lambda: False, Stream=lambda: None)
+        backends = types.SimpleNamespace(mps=types.SimpleNamespace(is_available=lambda: False))
+        super().__init__(cuda=cuda, backends=backends)
+
+sys.modules.setdefault("torch", _Torch())
+
+
+class _SNAC:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):  # pragma: no cover - simple stub
+        return cls()
+
+    def eval(self):
+        return self
+
+    def to(self, *args, **kwargs):  # noqa: D401
+        return self
+
+    def decode(self, codes):
+        return types.SimpleNamespace()
+
+sys.modules.setdefault("snac", types.SimpleNamespace(SNAC=_SNAC))

--- a/tests/test_start_requires_orpheus_cpp.py
+++ b/tests/test_start_requires_orpheus_cpp.py
@@ -1,0 +1,18 @@
+import builtins
+import importlib
+import pytest
+
+
+def test_start_errors_when_orpheus_cpp_missing(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "orpheus_cpp":
+            raise ImportError("missing")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    start = importlib.import_module("scripts.start")
+    with pytest.raises(SystemExit) as exc:
+        start.main()
+    assert "orpheus_cpp is required" in str(exc.value)


### PR DESCRIPTION
## Summary
- add `orpheus-cpp` to pinned requirements and document build steps
- fail fast in `scripts/start.py` when `orpheus_cpp` is missing
- cover startup dependency check with tests and stub native modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4a82d1f28832c933f7491e0fbaed2