### PR TITLE
Expose config persistence API

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -250,3 +250,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** –
 
+### [2025-10-09] config-persistence
+
+- **Context:** Configuration changes via the API were volatile and lost on restart.
+- **Decision:** Expose `GET /config` and persist `POST /config` updates through `Morpheus_Client.config.save_config`.
+- **Alternatives:** Keep in-memory configuration only.
+- **Trade-offs:** `.env` rewrites may race under concurrent updates.
+- **Scope:** `Morpheus_Client/server.py`, `INTERFACES.md`, `tests/test_text_sources.py`.
+- **Impact:** Config changes round-trip through `.env` and survive restarts.
+- **TTL / Review:** revisit when multi-user config or locking is needed.
+- **Status:** active
+- **Links:** goal admin-interface
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -117,7 +117,7 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Compatibility:** auth TBD; persists changes to `.env`.
 - **Status:** active
 - **Owner:** repo owner
-- **Linked Scenes:** TBD
+- **Linked Scenes:** `tests/test_text_sources.py::test_config_round_trip_persistence`
 - **Linked Decisions:** [2025-09-01] single-service-architecture
 - **Notes:** n/a
 

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -69,11 +69,15 @@
 
 ### Surface: config-endpoint
 - **Type:** API
-- **Purpose:** Update active adapter, voice or text source.
+- **Purpose:** Read and update configuration.
 - **Shape:**
-  - **Request/Input:** `POST /config` with `{adapter?, voice?, source?}`
-  - **Response/Output:** `{adapter, voice, source}` (non-streaming JSON)
-- **Idempotency/Retry:** repeated calls override current state
+  - **Request/Input:**
+    - `GET /config`
+    - `POST /config` with `{adapter?, voice?, source?, ORPHEUS_*?}`
+  - **Response/Output:**
+    - `GET` → `{...}` current config
+    - `POST` → `{message, adapter?, voice?, source?}`
+- **Idempotency/Retry:** `GET` is idempotent; `POST` overwrites provided keys
 - **Stability:** experimental
 - **Versioning:** none
 - **Auth/Access:** operator only
@@ -84,6 +88,7 @@
 - **Change Log:**
   - 2025-09-01: documented endpoint
   - 2025-09-14: added text source configuration
+  - 2025-10-09: added GET and persistence via `.env`
 
 ### Surface: admin-endpoint
 - **Type:** API

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 Single ASGI service exposing:
 
 - `POST /v1/audio/speech` – streams WAV audio chunks
-- `POST /config` – updates adapter, voice, or text source
+- `GET /config` – returns current configuration
+- `POST /config` – updates adapter, voice, text source or env vars and persists
 - `GET /stats` – returns runtime telemetry
 - `GET /admin` – serves operator dashboard
 


### PR DESCRIPTION
## Task
- **WHY:** config updates via `/config` vanished on restart, hindering admin control.
- **OUTCOME:** server exposes `GET /config` and persistent `POST /config` that writes `.env` through `Morpheus_Client.config.save_config`.
- **SURFACES TOUCHED:** `Morpheus_Client/server.py`, `INTERFACES.md`, `README.md`, `tests/test_text_sources.py`.
- **EXIT VIA SCENES:** `pytest` including `tests/test_text_sources.py::test_config_round_trip_persistence`.
- **COMPATIBILITY:** additive; existing clients may POST same fields, now persisted.
- **NO-GO:** failing tests or missing dependencies.

## Summary
- add GET and persistent POST `/config` endpoints
- document config API and link scene in goal ledger
- cover round-trip persistence with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4aa2764a4832c900d71e8d28850c6