### PR TITLE
Align admin config with /config API

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -18,6 +18,17 @@
 - **Links:** <PRs, scenes, interface entries, goal names>
 
 _(New entries go on top. Keep each under ~20 lines.)_
+### [2025-10-15] admin-config-cleanup
+
+- **Context:** Admin UI retained FastAPI branding and referenced a non-existent restart endpoint; config selectors omitted voice, adapter, and source.
+- **Decision:** Drop FastAPI branding and restart controls, and wire voice, adapter, and text-source selectors through `/config`.
+- **Alternatives:** Keep legacy branding and dead controls.
+- **Trade-offs:** Slightly more client-side code; removes explicit restart flow.
+- **Scope:** `Morpheus_Client/admin/tts.html`.
+- **Impact:** UI aligns with current config API; removes broken endpoints.
+- **TTL / Review:** revisit when admin features grow.
+- **Status:** ACTIVE
+- **Links:** interfaces config-endpoint
 ### [2025-09-30] orpheus-cpp-required
 
 - **Context:** Starting the service without `orpheus_cpp` led to runtime failures during synthesis.

--- a/Morpheus_Client/admin/tts.html
+++ b/Morpheus_Client/admin/tts.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Orpheus FASTAPI | Advanced Text-to-Speech</title>
+  <title>Orpheus Admin | Advanced Text-to-Speech</title>
   <link rel="icon" href="/admin/static/favicon.svg" type="image/svg+xml">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -84,7 +84,7 @@
         <div class="flex h-16 items-center justify-between">
           <div class="flex items-center">
             <div class="flex-shrink-0">
-              <span class="text-white text-xl font-bold">Orpheus FASTAPI</span>
+              <span class="text-white text-xl font-bold">Orpheus Admin</span>
             </div>
           </div>
           <div class="flex items-center space-x-4">
@@ -270,7 +270,7 @@
                   <!-- Server configuration section -->
                   <div class="mt-6 border-t border-dark-700 pt-4">
                     <h3 class="text-sm font-medium text-white mb-3">Server Configuration</h3>
-                    <p class="text-xs text-purple-300 mb-3">These settings will be saved to a <code class="bg-dark-700 px-1 rounded">.env</code> file. Restart the server to apply changes.</p>
+                    <p class="text-xs text-purple-300 mb-3">These settings will be saved to a <code class="bg-dark-700 px-1 rounded">.env</code> file.</p>
                     
                     <!-- Form fields for all .env parameters -->
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -330,15 +330,21 @@
                                class="block w-full rounded-md bg-dark-700 border-dark-600 text-white text-sm focus:border-primary-500 focus:ring-primary-500 focus:ring-offset-dark-800 px-3 py-2">
                       </div>
                       
-                      <!-- Save button and restart button -->
+                      <div>
+                        <label for="adapter-select" class="block text-xs font-medium text-white mb-1">Adapter</label>
+                        <select id="adapter-select" name="adapter" class="block w-full rounded-md bg-dark-700 border-dark-600 text-white text-sm focus:border-primary-500 focus:ring-primary-500 focus:ring-offset-dark-800 pl-3 pr-10 py-2 appearance-none"></select>
+                      </div>
+
+                      <div>
+                        <label for="source-select" class="block text-xs font-medium text-white mb-1">Text Source</label>
+                        <select id="source-select" name="source" class="block w-full rounded-md bg-dark-700 border-dark-600 text-white text-sm focus:border-primary-500 focus:ring-primary-500 focus:ring-offset-dark-800 pl-3 pr-10 py-2 appearance-none"></select>
+                      </div>
+
+                      <!-- Save button -->
                       <div class="col-span-1 md:col-span-2 mt-4 flex flex-col md:flex-row gap-4">
-                        <button id="save-config-btn" type="button" 
+                        <button id="save-config-btn" type="button"
                                 class="btn-primary bg-purple-600 hover:bg-purple-700 active:bg-purple-800 w-full md:w-auto">
                           Save Configuration
-                        </button>
-                        <button id="restart-server-btn" type="button" 
-                                class="btn-primary bg-red-600 hover:bg-red-700 active:bg-red-800 w-full md:w-auto hidden">
-                          Restart Server
                         </button>
                         <p class="text-xs text-purple-300 mt-2 flex-grow">
                           <span id="config-status" class="hidden"></span>
@@ -386,7 +392,7 @@
     <footer class="bg-dark-900 border-t border-dark-700 py-6">
       <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div class="flex justify-center">
-          <span class="text-purple-300 text-sm">Powered by <a href="https://fastapi.tiangolo.com/" target="_blank" class="text-primary-400 hover:text-primary-300">FASTAPI</a></span>
+          <span class="text-purple-300 text-sm">Project Morpheus</span>
         </div>
       </div>
     </footer>
@@ -679,13 +685,44 @@
       // Configuration management
       async function loadConfigValues() {
         try {
-          const response = await fetch('/config');
-          if (!response.ok) {
-            throw new Error('Failed to load configuration');
+          const [cfgRes, adaptersRes, sourcesRes] = await Promise.all([
+            fetch('/config'),
+            fetch('/adapters'),
+            fetch('/sources')
+          ]);
+
+          if (!cfgRes.ok) throw new Error('Failed to load configuration');
+          if (!adaptersRes.ok) throw new Error('Failed to load adapters');
+          if (!sourcesRes.ok) throw new Error('Failed to load sources');
+
+          const config = await cfgRes.json();
+          const adapters = await adaptersRes.json();
+          const sources = await sourcesRes.json();
+
+          // Populate adapter select
+          const adapterSelect = document.getElementById('adapter-select');
+          adapters.forEach(name => {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            adapterSelect.appendChild(opt);
+          });
+          if (config.adapter) {
+            adapterSelect.value = config.adapter;
           }
-          
-          const config = await response.json();
-          
+
+          // Populate source select
+          const sourceSelect = document.getElementById('source-select');
+          sources.forEach(name => {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            sourceSelect.appendChild(opt);
+          });
+          if (config.source) {
+            sourceSelect.value = config.source;
+          }
+
           // Populate form fields with config values
           document.querySelectorAll('input[name^="ORPHEUS_"]').forEach(input => {
             const name = input.name;
@@ -693,22 +730,52 @@
               input.value = config[name];
             }
           });
-          
+
+          // Set voice selection
+          if (config.voice) {
+            const voiceName = typeof config.voice === 'object' ? config.voice.voice : config.voice;
+            const voiceInput = document.querySelector(`input[name="voice"][value="${voiceName}"]`);
+            if (voiceInput) {
+              voiceInput.checked = true;
+              voiceCards.forEach(c => c.classList.remove('active'));
+              const card = voiceInput.closest('.voice-card');
+              if (card) {
+                card.classList.add('active');
+              }
+            }
+          }
+
           console.log('Configuration loaded successfully');
         } catch (error) {
           console.error('Error loading configuration:', error);
         }
       }
-      
+
       // Save configuration
       async function saveConfiguration() {
         const configData = {};
-        
+
         // Collect values from all configuration inputs
         document.querySelectorAll('input[name^="ORPHEUS_"]').forEach(input => {
           configData[input.name] = input.value;
         });
-        
+
+        // Include voice, adapter, and text source selections
+        const selectedVoice = document.querySelector('input[name="voice"]:checked');
+        if (selectedVoice) {
+          configData.voice = selectedVoice.value;
+        }
+
+        const adapterSelect = document.getElementById('adapter-select');
+        if (adapterSelect && adapterSelect.value) {
+          configData.adapter = adapterSelect.value;
+        }
+
+        const sourceSelect = document.getElementById('source-select');
+        if (sourceSelect && sourceSelect.value) {
+          configData.source = sourceSelect.value;
+        }
+
         try {
           const response = await fetch('/config', {
             method: 'POST',
@@ -717,33 +784,33 @@
             },
             body: JSON.stringify(configData)
           });
-          
+
           if (!response.ok) {
             throw new Error('Failed to save configuration');
           }
-          
+
           const result = await response.json();
-          
+
           // Show success message
           const statusElem = document.getElementById('config-status');
           statusElem.textContent = result.message;
           statusElem.classList.remove('hidden');
           statusElem.classList.add('text-green-400');
-          
+
           // Hide message after 5 seconds
           setTimeout(() => {
             statusElem.classList.add('hidden');
           }, 5000);
-          
+
         } catch (error) {
           console.error('Error saving configuration:', error);
-          
+
           // Show error message
           const statusElem = document.getElementById('config-status');
           statusElem.textContent = 'Error saving configuration. Please try again.';
           statusElem.classList.remove('hidden');
           statusElem.classList.add('text-red-400');
-          
+
           // Hide message after 5 seconds
           setTimeout(() => {
             statusElem.classList.add('hidden');
@@ -751,88 +818,9 @@
         }
       }
       
-      // Function to restart the server
-      async function restartServer() {
-        const restartBtn = document.getElementById('restart-server-btn');
-        restartBtn.disabled = true;
-        restartBtn.textContent = 'Restarting...';
-        
-        try {
-          const response = await fetch('/restart_server', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json'
-            }
-          });
-          
-          if (!response.ok) {
-            throw new Error('Failed to restart server');
-          }
-          
-          const result = await response.json();
-          
-          // Show server restarting message and overlay
-          const statusElem = document.getElementById('config-status');
-          statusElem.textContent = result.message;
-          statusElem.classList.remove('hidden');
-          statusElem.classList.add('text-yellow-400');
-          
-          // Show loading overlay with different message
-          const loadingOverlay = document.getElementById('loading-overlay');
-          loadingOverlay.querySelector('p').textContent = 'Server is restarting...';
-          loadingOverlay.classList.remove('hidden');
-          
-          // Poll for server readiness, then do a complete page reload with cache busting
-          function checkServerReady() {
-            console.log("Checking if server is ready...");
-            fetch('/config?cache=' + Date.now(), {
-              cache: 'no-store',
-              headers: { 'pragma': 'no-cache' }
-            })
-              .then(response => {
-                if (response.ok) {
-                  console.log("Server is up and running, forcing complete page reload");
-                  // Force a complete reload with cache busting
-                  window.location = window.location.pathname + '?t=' + Date.now();
-                } else {
-                  console.log("Server not ready yet, status: " + response.status);
-                  setTimeout(checkServerReady, 1000);
-                }
-              })
-              .catch(error => {
-                console.log("Server not responding yet, waiting...");
-                setTimeout(checkServerReady, 1000);
-              });
-          }
+      // Save configuration on button click
+      document.getElementById('save-config-btn').addEventListener('click', saveConfiguration);
 
-          // Start checking after initial delay
-          setTimeout(checkServerReady, 2000);
-          
-        } catch (error) {
-          console.error('Error restarting server:', error);
-          
-          // Show error message
-          const statusElem = document.getElementById('config-status');
-          statusElem.textContent = 'Error restarting server. Please try again.';
-          statusElem.classList.remove('hidden');
-          statusElem.classList.add('text-red-400');
-          
-          // Reset button
-          restartBtn.disabled = false;
-          restartBtn.textContent = 'Restart Server';
-        }
-      }
-      
-      // Add event listeners
-      document.getElementById('save-config-btn').addEventListener('click', function() {
-        saveConfiguration();
-        // Show restart button after saving
-        const restartBtn = document.getElementById('restart-server-btn');
-        restartBtn.classList.remove('hidden');
-      });
-      
-      document.getElementById('restart-server-btn').addEventListener('click', restartServer);
-      
       // Load configuration values when page loads
       loadConfigValues();
     });


### PR DESCRIPTION
## Summary
- remove FastAPI branding and dead restart button
- drive voice/adapter/source selectors through `/config`
- document change in DECISIONS.log

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4accbc650832c9f098361c786b88c