### PR TITLE
Stream text sources into orchestrator

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -273,3 +273,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** goal admin-interface
 
+### [2025-10-24] source-runner
+
+- **Context:** Text sources were selectable but not consumed automatically.
+- **Decision:** Instantiate sources via registry and stream their output to `orchestrated_pcm_stream` in a background task.
+- **Alternatives:** Require manual piping for each request.
+- **Trade-offs:** Introduces an additional long-lived asyncio task per active source.
+- **Scope:** `Morpheus_Client/server.py`, `tests/test_text_sources.py`.
+- **Impact:** WebSocket and CLI feeds drive synthesis without bespoke wiring.
+- **TTL / Review:** review when multiple concurrent sources are supported.
+- **Status:** active
+- **Links:** goal pluggable-text-sources
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -176,7 +176,9 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Compatibility:** selectable via `/config`; no migrations.
 - **Status:** active
 - **Owner:** repo owner
-- **Linked Scenes:** TBD
+- **Linked Scenes:**
+  - `tests/test_text_sources.py::test_cli_pipe_feeds_orchestrator`
+  - `tests/test_text_sources.py::test_websocket_feeds_orchestrator`
 - **Linked Decisions:** [2025-09-14] text-source-adapters
 - **Notes:** initial adapters for WebSocket, HTTP polling and CLI pipe.
 

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -73,7 +73,7 @@
 - **Shape:**
   - **Request/Input:**
     - `GET /config`
-    - `POST /config` with `{adapter?, voice?, source?, ORPHEUS_*?}`
+    - `POST /config` with `{adapter?, voice?, source?, source_config?, ORPHEUS_*?}`
   - **Response/Output:**
     - `GET` → `{...}` current config
     - `POST` → `{message, adapter?, voice?, source?}`
@@ -89,6 +89,7 @@
   - 2025-09-01: documented endpoint
   - 2025-09-14: added text source configuration
   - 2025-10-09: added GET and persistence via `.env`
+  - 2025-10-24: allow `source_config` for constructor options
 
 ### Surface: admin-endpoint
 - **Type:** API

--- a/tests/test_text_sources.py
+++ b/tests/test_text_sources.py
@@ -12,7 +12,7 @@ sys.modules.setdefault("sounddevice", types.SimpleNamespace())
 from text_sources.cli_pipe import CLIPipeSource
 from text_sources.http_poll import HTTPPollingSource
 from text_sources.websocket import WebSocketSource
-from Morpheus_Client.server import app
+import Morpheus_Client.server as server
 from Morpheus_Client.config import get_current_config
 
 
@@ -71,7 +71,7 @@ def test_websocket_source():
 
 def test_config_round_trip_persistence():
     async def run():
-        transport = httpx.ASGITransport(app=app)
+        transport = httpx.ASGITransport(app=server.app)
         async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
             await client.post("/config", json={"source": "cli_pipe"})
             resp = await client.get("/config")
@@ -81,3 +81,57 @@ def test_config_round_trip_persistence():
     assert resp.status_code == 200
     assert resp.json()["source"] == "cli_pipe"
     assert get_current_config()["source"] == "cli_pipe"
+
+
+def test_cli_pipe_feeds_orchestrator():
+    async def run():
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"a\nb\n")
+        reader.feed_eof()
+        calls: list[str] = []
+
+        async def fake(prompt: str, voice=None, **kwargs):
+            calls.append(prompt)
+            if False:
+                yield b""  # pragma: no cover - generator placeholder
+
+        orig = server.orchestrated_pcm_stream
+        server.orchestrated_pcm_stream = fake
+        try:
+            await server.init_source("cli_pipe", reader=reader)
+            await server.current_source_task
+        finally:
+            server.orchestrated_pcm_stream = orig
+            server.current_source_task = None
+        return calls
+
+    assert asyncio.run(run()) == ["a", "b"]
+
+
+def test_websocket_feeds_orchestrator():
+    async def run():
+        calls: list[str] = []
+
+        async def fake(prompt: str, voice=None, **kwargs):
+            calls.append(prompt)
+            if False:
+                yield b""
+
+        orig = server.orchestrated_pcm_stream
+        server.orchestrated_pcm_stream = fake
+        try:
+            async def ws_handler(ws):
+                await ws.send("x")
+                await ws.send("y")
+                await ws.close()
+
+            async with websockets.serve(ws_handler, "localhost", 0) as ws_srv:
+                port = ws_srv.sockets[0].getsockname()[1]
+                await server.init_source("websocket", uri=f"ws://localhost:{port}")
+                await server.current_source_task
+        finally:
+            server.orchestrated_pcm_stream = orig
+            server.current_source_task = None
+        return calls
+
+    assert asyncio.run(run()) == ["x", "y"]


### PR DESCRIPTION
## Summary
- run active `TextSource` in a background task and forward its text into `orchestrated_pcm_stream`
- allow `/config` to pass `source_config` and trigger source instantiation on change
- add scenes verifying CLI pipe and WebSocket feeds reach the orchestrator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4af611e6c832c808160e624d2498e