### PR TITLE
Log and expose transcript history

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -285,3 +285,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** goal pluggable-text-sources
 
+### [2025-10-30] orchestrator-transcripts
+
+- **Context:** Need to retain utterance text for replay and operator insight.
+- **Decision:** Record `{timestamp,text}` per utterance, expose transcripts via `/stats`, and persist them to `SCENES/_artifacts/transcripts.json`.
+- **Alternatives:** Depend solely on unstructured logs.
+- **Trade-offs:** Transcript list grows unbounded; potential privacy concerns.
+- **Scope:** `Morpheus_Client/orchestrator/core.py`, `Morpheus_Client/server.py`, `scenes/utils.py`, `tests/*`.
+- **Impact:** Enables replayable transcript history alongside timeline events.
+- **TTL / Review:** revisit when persistence or pruning is required.
+- **Status:** active
+- **Links:** goal transcript-history
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -206,3 +206,15 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** `tests/test_start_requires_orpheus_cpp.py`
 - **Linked Decisions:** [2025-09-30] orpheus-cpp-required
 - **Notes:** build step may take several minutes
+
+### Capability: transcript-history
+
+- **Purpose:** Retain utterance text for replay and monitoring.
+- **Scope:** `Morpheus_Client/orchestrator`, `/stats` API, `SCENES/_artifacts`.
+- **Shape:** `{timestamp,text}` entries appended per utterance; `/stats` exposes transcript list; transcripts persisted to `SCENES/_artifacts/transcripts.json`.
+- **Compatibility:** additive; resets on process restart.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `tests/test_stats_endpoint.py::test_stats_endpoint_exposes_timeline`, `tests/test_scenes.py::test_breathing_room`
+- **Linked Decisions:** [2025-10-30] orchestrator-transcripts
+- **Notes:** transcripts list grows without bound

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -52,20 +52,21 @@
 
 ### Surface: stats-endpoint
 - **Type:** API
-- **Purpose:** Expose orchestrator timeline for live monitoring.
+- **Purpose:** Expose orchestrator timeline and transcripts for live monitoring.
 - **Shape:**
   - **Request/Input:** `GET /stats`
-  - **Response/Output:** `{ "timeline": [<timeline-events>] }` (non-streaming JSON)
+  - **Response/Output:** `{ "timeline": [<timeline-events>], "transcripts": [ {timestamp,text} ] }` (non-streaming JSON)
 - **Idempotency/Retry:** read-only; safe to retry.
 - **Stability:** experimental
 - **Versioning:** none
 - **Auth/Access:** operator only
-- **Observability:** timeline events appended in memory
+- **Observability:** timeline events and transcripts appended in memory
 - **Failure Modes:** `503` when orchestrator not initialized
 - **Owner:** repo owner
 - **Code:** `Morpheus_Client/server.py`
 - **Change Log:**
   - 2025-09-21: updated shape to timeline JSON
+  - 2025-09-27: added transcript history to response
 
 ### Surface: config-endpoint
 - **Type:** API

--- a/Morpheus_Client/server.py
+++ b/Morpheus_Client/server.py
@@ -143,6 +143,7 @@ async def orchestrated_pcm_stream(
     )
     buffer = PlaybackBuffer(capacity_ms=1000)
     current_orchestrator = Orchestrator(adapter, buffer, ChunkLadder())
+    current_orchestrator.log_transcript(prompt)
     stitched = stitch_chunks(
         current_orchestrator.stream(), sample_rate=SAMPLE_RATE
     )
@@ -279,10 +280,15 @@ async def update_config(request: Request) -> JSONResponse:
 
 
 async def stats(request: Request) -> JSONResponse:
-    """Return the current orchestrator timeline for live monitoring."""
+    """Return current timeline and transcript history for monitoring."""
 
-    timeline = [] if current_orchestrator is None else current_orchestrator.timeline
-    return JSONResponse({"timeline": timeline})
+    if current_orchestrator is None:
+        timeline: list[dict] = []
+        transcripts: list[dict] = []
+    else:
+        timeline = current_orchestrator.timeline
+        transcripts = current_orchestrator.transcripts
+    return JSONResponse({"timeline": timeline, "transcripts": transcripts})
 
 
 async def barge_in(request: Request) -> JSONResponse:  # pragma: no cover - simple

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Single ASGI service exposing:
 - `POST /v1/audio/speech` – streams WAV audio chunks
 - `GET /config` – returns current configuration
 - `POST /config` – updates adapter, voice, text source or env vars and persists
-- `GET /stats` – returns runtime telemetry
+- `GET /stats` – returns runtime telemetry and transcript history
 - `GET /admin` – serves operator dashboard
 
 ## Installation

--- a/scenes/utils.py
+++ b/scenes/utils.py
@@ -33,6 +33,7 @@ def run_scene(scene_name: str, adapter, tmp_path: Path, barge_in_at: int | None 
     """
     buffer = PlaybackBuffer(capacity_ms=1000)
     orch = Orchestrator(adapter, buffer, ChunkLadder())
+    orch.log_transcript(scene_name)
     timeline: list[dict] = []
     audio_bytes = bytearray()
     start = time.perf_counter()

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -45,6 +45,11 @@ def test_breathing_room(artifact_dir):
     with open(global_path, "r", encoding="utf-8") as fh:
         data = json.load(fh)
     assert "events" in data and isinstance(data["events"], list)
+    transcript_path = Path("SCENES/_artifacts/transcripts.json")
+    assert transcript_path.exists()
+    with open(transcript_path, "r", encoding="utf-8") as fh:
+        transcripts = json.load(fh)
+    assert transcripts[0]["text"] == "breathing_room"
 
 
 def test_long_read(artifact_dir):

--- a/tests/test_stats_endpoint.py
+++ b/tests/test_stats_endpoint.py
@@ -32,6 +32,7 @@ def test_stats_endpoint_exposes_timeline():
     adapter = DummyAdapter([AudioChunk(pcm=b"", duration_ms=10, eos=True)])
     orch = Orchestrator(adapter, PlaybackBuffer(capacity_ms=500), ChunkLadder())
     server.current_orchestrator = orch
+    orch.log_transcript("hello")
 
     async def run():
         async for _ in orch.stream():
@@ -49,4 +50,6 @@ def test_stats_endpoint_exposes_timeline():
     body = resp.json()
     assert "timeline" in body
     assert isinstance(body["timeline"], list)
+    assert "transcripts" in body
+    assert body["transcripts"][0]["text"] == "hello"
 


### PR DESCRIPTION
## Summary
- record `{timestamp, text}` transcripts for each utterance and persist them to `SCENES/_artifacts/transcripts.json`
- expose transcript history alongside timeline via `/stats`
- document new capability and update interface docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4b2ee71dc832c9c91bf16242baf71