### PR TITLE
feat: fetch voices dynamically

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -309,3 +309,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** goal user-config-precedence
 
+### [2025-08-19] admin-voices-runtime
+
+- **Context:** Admin template embedded voice and language options via Jinja, preventing `/admin` from being served purely as static assets.
+- **Decision:** Remove server-side templating and fetch voices and languages from `/v1/audio/voices` at runtime.
+- **Alternatives:** Pre-render voices into HTML during build.
+- **Trade-offs:** Adds client-side rendering dependency and requires API availability on initial load.
+- **Scope:** `Morpheus_Client/admin/tts.html`, `Morpheus_Client/server.py`, `tests/test_admin_dynamic_voices.py`
+- **Impact:** `/admin` assets are static and voice lists stay in sync with backend at runtime.
+- **TTL / Review:** revisit if voices endpoint becomes unstable or large.
+- **Status:** active
+- **Links:** goal admin-voices-runtime
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -230,3 +230,15 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** `tests/test_text_sources.py`
 - **Linked Decisions:** [2025-08-19] user-config-precedence
 - **Notes:** home directory config created on save
+
+### Capability: admin-voices-runtime
+
+- **Purpose:** Admin UI loads available voices and languages at runtime from the API.
+- **Scope:** `Morpheus_Client/admin/tts.html`, `Morpheus_Client/server.py`
+- **Shape:** `/v1/audio/voices` returns voice-language mapping; admin page fetches and renders dynamically.
+- **Compatibility:** additive to existing voice list API; static `/admin` assets remain unchanged by backend config.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `tests/test_admin_dynamic_voices.py::test_admin_voices_loaded_via_api`
+- **Linked Decisions:** [2025-08-19] admin-voices-runtime
+- **Notes:** initial load depends on voices endpoint availability

--- a/Morpheus_Client/admin/tts.html
+++ b/Morpheus_Client/admin/tts.html
@@ -100,35 +100,7 @@
       <div class="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         
         <!-- Notification area -->
-        {% if error %}
-        <div class="mb-6 bg-red-50 border-l-4 border-red-400 p-4 rounded-md shadow-sm">
-          <div class="flex">
-            <div class="flex-shrink-0">
-              <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-              </svg>
-            </div>
-            <div class="ml-3">
-              <p class="text-sm text-red-700">{{ error }}</p>
-            </div>
-          </div>
-        </div>
-        {% endif %}
-
-        {% if success %}
-        <div class="mb-6 bg-green-50 border-l-4 border-green-400 p-4 rounded-md shadow-sm">
-          <div class="flex">
-            <div class="flex-shrink-0">
-              <svg class="h-5 w-5 text-green-400" viewBox="0 0 20 20" fill="currentColor">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
-              </svg>
-            </div>
-            <div class="ml-3">
-              <p class="text-sm text-green-700">Audio generated successfully in {{ generation_time }}s!</p>
-            </div>
-          </div>
-        </div>
-        {% endif %}
+        <div id="notification-area"></div>
         
         <!-- TTS form -->
         <div class="bg-dark-800 shadow-lg rounded-lg overflow-hidden border border-dark-700">
@@ -148,7 +120,7 @@
                     class="block w-full rounded-md border-dark-600 bg-dark-700 text-white shadow-sm focus:border-primary-500 focus:ring-primary-500 focus:ring-offset-dark-800 sm:text-sm px-3 py-2"
                     placeholder="Enter text to convert to speech..."
                     required
-                  >{{ text if text else "" }}</textarea>
+                  ></textarea>
                   <div class="absolute bottom-2 right-2 text-xs text-purple-300">
                     <span id="char-count">0</span> / 8192 characters
                   </div>
@@ -158,74 +130,13 @@
               <!-- Language selection -->
               <div class="mb-6">
                 <label class="block text-sm font-medium text-white mb-2">Language</label>
-                <div class="flex flex-wrap gap-3">
-                  {% for language in AVAILABLE_LANGUAGES %}
-                  <div class="language-option {% if language == 'english' %}active{% endif %}" data-language="{{ language }}">
-                    <input type="radio" name="language" value="{{ language }}" class="hidden" {% if language == 'english' %}checked{% endif %}>
-                    <span class="px-3 py-1 rounded-full bg-dark-700 hover:bg-dark-600 text-white text-sm cursor-pointer">{{ language|capitalize }}</span>
-                  </div>
-                  {% endfor %}
-                </div>
+                <div id="language-options" class="flex flex-wrap gap-3"></div>
               </div>
 
               <!-- Voice selection -->
               <div class="mb-6">
                 <label class="block text-sm font-medium text-white mb-2">Voice</label>
-                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-                  {% for voice_option in voices %}
-                  <div class="voice-card {% if voice_option == DEFAULT_VOICE %}active{% endif %}" 
-                       data-voice="{{ voice_option }}" 
-                       data-language="{{ VOICE_TO_LANGUAGE[voice_option] }}"
-                       style="display: {% if VOICE_TO_LANGUAGE[voice_option] != 'english' %}none{% endif %}">
-                    <input type="radio" name="voice" value="{{ voice_option }}" class="hidden" {% if voice_option == DEFAULT_VOICE %}checked{% endif %}>
-                    <div class="flex items-center mb-2">
-                      <span class="font-medium text-white">{{ voice_option|capitalize }}</span>
-                    </div>
-                    <div class="text-xs text-dark-300">
-                      {% if voice_option == "tara" %}Female, English, conversational, clear
-                      {% elif voice_option == "leah" %}Female, English, warm, gentle
-                      {% elif voice_option == "jess" %}Female, English, energetic, youthful
-                      {% elif voice_option == "leo" %}Male, English, authoritative, deep
-                      {% elif voice_option == "dan" %}Male, English, friendly, casual
-                      {% elif voice_option == "mia" %}Female, English, professional, articulate
-                      {% elif voice_option == "zac" %}Male, English, enthusiastic, dynamic
-                      {% elif voice_option == "zoe" %}Female, English, calm, soothing
-                      
-                      <!-- French voices -->
-                      {% elif voice_option == "pierre" %}Male, French, sophisticated
-                      {% elif voice_option == "amelie" %}Female, French, elegant
-                      {% elif voice_option == "marie" %}Female, French, spirited
-                      
-                      <!-- German voices -->
-                      {% elif voice_option == "jana" %}Female, German, clear
-                      {% elif voice_option == "thomas" %}Male, German, authoritative
-                      {% elif voice_option == "max" %}Male, German, energetic
-                      
-                      <!-- Korean voices -->
-                      {% elif voice_option == "유나" %}Female, Korean, melodic
-                      {% elif voice_option == "준서" %}Male, Korean, confident
-                      
-                      <!-- Hindi voice -->
-                      {% elif voice_option == "ऋतिका" %}Female, Hindi, expressive
-                      
-                      <!-- Mandarin voices -->
-                      {% elif voice_option == "长乐" %}Female, Mandarin, gentle
-                      {% elif voice_option == "白芷" %}Female, Mandarin, clear
-                      
-                      <!-- Spanish voices -->
-                      {% elif voice_option == "javi" %}Male, Spanish, warm
-                      {% elif voice_option == "sergio" %}Male, Spanish, professional
-                      {% elif voice_option == "maria" %}Female, Spanish, friendly
-                      
-                      <!-- Italian voices -->
-                      {% elif voice_option == "pietro" %}Male, Italian, passionate
-                      {% elif voice_option == "giulia" %}Female, Italian, expressive
-                      {% elif voice_option == "carlo" %}Male, Italian, refined
-                      {% endif %}
-                    </div>
-                  </div>
-                  {% endfor %}
-                </div>
+                <div id="voice-options" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4"></div>
               </div>
 
               <!-- Advanced options (can be expanded) -->
@@ -442,388 +353,277 @@
   </template>
 
   <!-- JavaScript for interactivity -->
-  <script>
-    document.addEventListener('DOMContentLoaded', function() {
-      // Global variables
-      let wavesurfer;
-      // Character counter
-      const textArea = document.getElementById('text');
-      const charCount = document.getElementById('char-count');
-      
-      textArea.addEventListener('input', function() {
-        charCount.textContent = textArea.value.length;
-      });
-      
-      // Initialize char count
+
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    let wavesurfer;
+    const textArea = document.getElementById('text');
+    const charCount = document.getElementById('char-count');
+
+    textArea.addEventListener('input', () => {
       charCount.textContent = textArea.value.length;
-      
-      // Language selection
+    });
+    charCount.textContent = textArea.value.length;
+
+    async function initVoices() {
+      try {
+        const res = await fetch('/v1/audio/voices');
+        if (!res.ok) throw new Error('Failed to load voices');
+        const data = await res.json();
+        populateVoiceUI(data);
+        attachVoiceHandlers();
+        await loadConfigValues();
+      } catch (err) {
+        console.error('Error loading voices:', err);
+      }
+    }
+
+    function capitalize(str) {
+      return str.charAt(0).toUpperCase() + str.slice(1);
+    }
+
+    function populateVoiceUI(data) {
+      const languageContainer = document.getElementById('language-options');
+      const voiceContainer = document.getElementById('voice-options');
+      const voices = data.voices || [];
+      const voiceToLang = data.voice_to_language || {};
+      const languages = data.languages || [...new Set(Object.values(voiceToLang))];
+      const defaultVoice = data.default || voices[0];
+      const defaultLang = voiceToLang[defaultVoice];
+
+      languages.forEach(lang => {
+        const active = lang == defaultLang ? ' active' : '';
+        const checked = lang == defaultLang ? ' checked' : '';
+        const div = document.createElement('div');
+        div.className = 'language-option' + active;
+        div.dataset.language = lang;
+        div.innerHTML = `<input type="radio" name="language" value="${lang}" class="hidden"${checked}><span class="px-3 py-1 rounded-full bg-dark-700 hover:bg-dark-600 text-white text-sm cursor-pointer">${capitalize(lang)}</span>`;
+        languageContainer.appendChild(div);
+      });
+
+      voices.forEach(voice => {
+        const lang = voiceToLang[voice];
+        const active = voice == defaultVoice ? ' active' : '';
+        const checked = voice == defaultVoice ? ' checked' : '';
+        const card = document.createElement('div');
+        card.className = 'voice-card' + active;
+        card.dataset.voice = voice;
+        card.dataset.language = lang;
+        card.style.display = lang == defaultLang ? '' : 'none';
+        card.innerHTML = `<input type="radio" name="voice" value="${voice}" class="hidden"${checked}><div class="flex items-center mb-2"><span class="font-medium text-white">${capitalize(voice)}</span></div>`;
+        voiceContainer.appendChild(card);
+      });
+    }
+
+    function attachVoiceHandlers() {
       const languageOptions = document.querySelectorAll('.language-option');
       const voiceCards = document.querySelectorAll('.voice-card');
-      
+
       languageOptions.forEach(option => {
         option.addEventListener('click', function() {
-          // Unselect all language options
           languageOptions.forEach(o => o.classList.remove('active'));
-          
-          // Select this language option
           this.classList.add('active');
-          
-          // Check the radio button
           const radio = this.querySelector('input[type="radio"]');
           radio.checked = true;
-          
-          // Get the selected language
           const selectedLanguage = this.getAttribute('data-language');
-          
-          // Show/hide voice cards based on language
           let firstVisibleCard = null;
-          
-          voiceCards.forEach(card => {
+          document.querySelectorAll('.voice-card').forEach(card => {
             const cardLanguage = card.getAttribute('data-language');
             if (cardLanguage === selectedLanguage) {
               card.style.display = '';
-              if (!firstVisibleCard) {
-                firstVisibleCard = card;
-              }
+              if (!firstVisibleCard) firstVisibleCard = card;
             } else {
               card.style.display = 'none';
-              // If this hidden card was selected, unselect it
               if (card.classList.contains('active')) {
                 card.classList.remove('active');
                 const cardRadio = card.querySelector('input[type="radio"]');
-                if (cardRadio) {
-                  cardRadio.checked = false;
-                }
+                if (cardRadio) cardRadio.checked = false;
               }
             }
           });
-          
-          // If no voice card is selected for this language, select the first one
-          if (firstVisibleCard && document.querySelectorAll(`.voice-card[data-language="${selectedLanguage}"].active:not([style*="display: none"])`).length === 0) {
+          if (firstVisibleCard && !document.querySelector(`.voice-card[data-language="${selectedLanguage}"].active`)) {
             firstVisibleCard.classList.add('active');
-            const firstVisibleRadio = firstVisibleCard.querySelector('input[type="radio"]');
-            if (firstVisibleRadio) {
-              firstVisibleRadio.checked = true;
-            }
+            const firstRadio = firstVisibleCard.querySelector('input[type="radio"]');
+            if (firstRadio) firstRadio.checked = true;
           }
         });
       });
-      
-      // Voice card selection
+
       voiceCards.forEach(card => {
         card.addEventListener('click', function() {
-          // Only allow selection of cards that are visible (not display:none)
-          if (this.style.display !== 'none') {
-            // Unselect all cards with the same language
-            const cardLanguage = this.getAttribute('data-language');
-            document.querySelectorAll(`.voice-card[data-language="${cardLanguage}"]`).forEach(c => {
-              c.classList.remove('active');
-              const radio = c.querySelector('input[type="radio"]');
-              if (radio) {
-                radio.checked = false;
-              }
-            });
-            
-            // Select this card
-            this.classList.add('active');
-            
-            // Check the radio button
-            const radio = this.querySelector('input[type="radio"]');
-            if (radio) {
-              radio.checked = true;
-            }
-          }
+          if (this.style.display === 'none') return;
+          const cardLanguage = this.getAttribute('data-language');
+          document.querySelectorAll(`.voice-card[data-language="${cardLanguage}"]`).forEach(c => {
+            c.classList.remove('active');
+            const radio = c.querySelector('input[type="radio"]');
+            if (radio) radio.checked = false;
+          });
+          this.classList.add('active');
+          const radio = this.querySelector('input[type="radio"]');
+          if (radio) radio.checked = true;
         });
       });
-      
-      // Speed slider
-      const speedSlider = document.getElementById('speed');
-      const speedValue = document.getElementById('speed-value');
-      
-      speedSlider.addEventListener('input', function() {
-        speedValue.textContent = speedSlider.value;
-      });
-      
-      // No preview buttons in this version
-      
-      // Function to initialize WaveSurfer
-      function initWaveSurfer(audioPath) {
-        // If wavesurfer already exists, destroy it to prevent memory leaks
-        if (wavesurfer) {
-          wavesurfer.destroy();
-        }
-        
-        // Create new wavesurfer instance
-        wavesurfer = WaveSurfer.create({
-          container: '#waveform',
-          waveColor: '#38bdf8',
-          progressColor: '#0284c7',
-          cursorColor: '#0ea5e9',
-          barWidth: 3,
-          barRadius: 3,
-          cursorWidth: 1,
-          height: 80,
-          barGap: 2,
-          responsive: true
-        });
-        
-        wavesurfer.load('/' + audioPath);
-        
-        wavesurfer.on('ready', function() {
-          const duration = wavesurfer.getDuration();
-          const minutes = Math.floor(duration / 60);
-          const seconds = Math.floor(duration % 60);
-          document.getElementById('audio-duration').textContent = 
-            `${minutes}:${seconds < 10 ? '0' + seconds : seconds}`;
-        });
-        
-        // Play button
-        const playBtn = document.getElementById('play-btn');
-        playBtn.addEventListener('click', function() {
-          wavesurfer.playPause();
-          
-          if (wavesurfer.isPlaying()) {
-            playBtn.innerHTML = `
-              <svg class="h-5 w-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 00-1 1v2a1 1 0 001 1h6a1 1 0 001-1V9a1 1 0 00-1-1H7z" clip-rule="evenodd" />
-              </svg>
-              Pause
-            `;
-          } else {
-            playBtn.innerHTML = `
-              <svg class="h-5 w-5 mr-2" fill="currentColor" viewBox="0 0 20 20">
-                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd" />
-              </svg>
-              Play
-            `;
-          }
-        });
-      }
-      
-      // Function to create and add the audio player to the DOM
-      function createAudioPlayer(response) {
-        const container = document.getElementById('audio-player-container');
-        const template = document.getElementById('audio-player-template');
-        
-        // Clone the template
-        const audioPlayer = template.content.cloneNode(true);
-        
-        // Clear previous player if exists
-        container.innerHTML = '';
-        
-        // Add the new player
-        container.appendChild(audioPlayer);
-        
-        // Set values
-        document.getElementById('voice-name').textContent = response.voice.charAt(0).toUpperCase() + response.voice.slice(1);
-        document.getElementById('generation-time').textContent = response.generation_time;
-        document.getElementById('download-link').href = '/' + response.output_file;
-        
-        // Initialize waveform
-        initWaveSurfer(response.output_file);
-      }
-      
-      // Form submission handler
-      const form = document.getElementById('tts-form');
-      form.addEventListener('submit', async function(event) {
-        // Prevent default form submission
-        event.preventDefault();
-        
-        // Get form data
-        const text = document.getElementById('text').value;
-        const voice = document.querySelector('input[name="voice"]:checked').value;
-        
-        if (!text.trim()) {
-          alert('Please enter some text to generate speech');
-          return;
-        }
-        
-        // Show loading overlay
-        document.getElementById('loading-overlay').classList.remove('hidden');
-        
-        try {
-          // Make API request to /v1/audio/speech endpoint
-          const response = await fetch('/v1/audio/speech', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-              text: text,
-              voice: voice
-            })
-          });
-          
-          if (!response.ok) {
-            throw new Error('Failed to generate speech');
-          }
-          
-          const data = await response.json();
-          
-          // Create audio player with response
-          createAudioPlayer(data);
-          
-        } catch (error) {
-          console.error('Error generating speech:', error);
-          alert('An error occurred while generating speech. Please try again.');
-        } finally {
-          // Hide loading overlay
-          document.getElementById('loading-overlay').classList.add('hidden');
-        }
-      });
-      
-      // Initialize audio player if output file exists from server-side rendering
-      {% if output_file %}
-      createAudioPlayer({
-        voice: "{{ voice if voice else DEFAULT_VOICE }}",
-        output_file: "{{ output_file }}",
-        generation_time: "{{ generation_time }}"
-      });
-      {% endif %}
-      
-      // Configuration management
-      async function loadConfigValues() {
-        try {
-          const [cfgRes, adaptersRes, sourcesRes] = await Promise.all([
-            fetch('/config'),
-            fetch('/adapters'),
-            fetch('/sources')
-          ]);
+    }
 
-          if (!cfgRes.ok) throw new Error('Failed to load configuration');
-          if (!adaptersRes.ok) throw new Error('Failed to load adapters');
-          if (!sourcesRes.ok) throw new Error('Failed to load sources');
-
-          const config = await cfgRes.json();
-          const adapters = await adaptersRes.json();
-          const sources = await sourcesRes.json();
-
-          // Populate adapter select
-          const adapterSelect = document.getElementById('adapter-select');
-          adapters.forEach(name => {
-            const opt = document.createElement('option');
-            opt.value = name;
-            opt.textContent = name;
-            adapterSelect.appendChild(opt);
-          });
-          if (config.adapter) {
-            adapterSelect.value = config.adapter;
-          }
-
-          // Populate source select
-          const sourceSelect = document.getElementById('source-select');
-          sources.forEach(name => {
-            const opt = document.createElement('option');
-            opt.value = name;
-            opt.textContent = name;
-            sourceSelect.appendChild(opt);
-          });
-          if (config.source) {
-            sourceSelect.value = config.source;
-          }
-
-          // Populate form fields with config values
-          document.querySelectorAll('input[name^="ORPHEUS_"]').forEach(input => {
-            const name = input.name;
-            if (config[name] !== undefined) {
-              input.value = config[name];
-            }
-          });
-
-          // Set voice selection
-          if (config.voice) {
-            const voiceName = typeof config.voice === 'object' ? config.voice.voice : config.voice;
-            const voiceInput = document.querySelector(`input[name="voice"][value="${voiceName}"]`);
-            if (voiceInput) {
-              voiceInput.checked = true;
-              voiceCards.forEach(c => c.classList.remove('active'));
-              const card = voiceInput.closest('.voice-card');
-              if (card) {
-                card.classList.add('active');
-              }
-            }
-          }
-
-          console.log('Configuration loaded successfully');
-        } catch (error) {
-          console.error('Error loading configuration:', error);
-        }
-      }
-
-      // Save configuration
-      async function saveConfiguration() {
-        const configData = {};
-
-        // Collect values from all configuration inputs
-        document.querySelectorAll('input[name^="ORPHEUS_"]').forEach(input => {
-          configData[input.name] = input.value;
-        });
-
-        // Include voice, adapter, and text source selections
-        const selectedVoice = document.querySelector('input[name="voice"]:checked');
-        if (selectedVoice) {
-          configData.voice = selectedVoice.value;
-        }
-
-        const adapterSelect = document.getElementById('adapter-select');
-        if (adapterSelect && adapterSelect.value) {
-          configData.adapter = adapterSelect.value;
-        }
-
-        const sourceSelect = document.getElementById('source-select');
-        if (sourceSelect && sourceSelect.value) {
-          configData.source = sourceSelect.value;
-        }
-
-        try {
-          const response = await fetch('/config', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(configData)
-          });
-
-          if (!response.ok) {
-            throw new Error('Failed to save configuration');
-          }
-
-          const result = await response.json();
-
-          // Show success message
-          const statusElem = document.getElementById('config-status');
-          statusElem.textContent = result.message;
-          statusElem.classList.remove('hidden');
-          statusElem.classList.add('text-green-400');
-
-          // Hide message after 5 seconds
-          setTimeout(() => {
-            statusElem.classList.add('hidden');
-          }, 5000);
-
-        } catch (error) {
-          console.error('Error saving configuration:', error);
-
-          // Show error message
-          const statusElem = document.getElementById('config-status');
-          statusElem.textContent = 'Error saving configuration. Please try again.';
-          statusElem.classList.remove('hidden');
-          statusElem.classList.add('text-red-400');
-
-          // Hide message after 5 seconds
-          setTimeout(() => {
-            statusElem.classList.add('hidden');
-          }, 5000);
-        }
-      }
-      
-      // Save configuration on button click
-      document.getElementById('save-config-btn').addEventListener('click', saveConfiguration);
-
-      // Load configuration values when page loads
-      loadConfigValues();
+    const speedSlider = document.getElementById('speed');
+    const speedValue = document.getElementById('speed-value');
+    speedSlider.addEventListener('input', function() {
+      speedValue.textContent = speedSlider.value;
     });
-  </script>
+
+    function initWaveSurfer(audioPath) {
+      if (wavesurfer) {
+        wavesurfer.destroy();
+      }
+      wavesurfer = WaveSurfer.create({
+        container: '#waveform',
+        waveColor: '#38bdf8',
+        progressColor: '#0284c7',
+        cursorColor: '#0ea5e9',
+        barWidth: 3,
+        barRadius: 3,
+        cursorWidth: 1,
+        height: 80,
+        barGap: 2,
+        responsive: true
+      });
+      wavesurfer.load('/' + audioPath);
+      wavesurfer.on('ready', function() {
+        const duration = wavesurfer.getDuration();
+        const minutes = Math.floor(duration / 60);
+        const seconds = Math.floor(duration % 60);
+        document.getElementById('audio-duration').textContent = `${minutes}:${seconds < 10 ? '0' + seconds : seconds}`;
+      });
+    }
+
+    function createAudioPlayer(response) {
+      const template = document.getElementById('audio-player-template');
+      const container = document.getElementById('audio-player-container');
+      container.innerHTML = '';
+      const clone = template.content.cloneNode(true);
+      container.appendChild(clone);
+      document.getElementById('voice-name').textContent = capitalize(response.voice);
+      document.getElementById('generation-time').textContent = response.generation_time;
+      document.getElementById('download-link').href = '/' + response.output_file;
+      initWaveSurfer(response.output_file);
+    }
+
+    const form = document.getElementById('tts-form');
+    form.addEventListener('submit', async function(event) {
+      event.preventDefault();
+      const text = textArea.value;
+      const voiceInput = document.querySelector('input[name="voice"]:checked');
+      if (!text.trim() || !voiceInput) {
+        alert('Please enter text and select a voice');
+        return;
+      }
+      document.getElementById('loading-overlay').classList.remove('hidden');
+      try {
+        const response = await fetch('/v1/audio/speech', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text, voice: voiceInput.value })
+        });
+        if (!response.ok) throw new Error('Failed to generate speech');
+        const data = await response.json();
+        createAudioPlayer(data);
+      } catch (error) {
+        console.error('Error generating speech:', error);
+        alert('An error occurred while generating speech. Please try again.');
+      } finally {
+        document.getElementById('loading-overlay').classList.add('hidden');
+      }
+    });
+
+    async function loadConfigValues() {
+      try {
+        const [cfgRes, adaptersRes, sourcesRes] = await Promise.all([
+          fetch('/config'),
+          fetch('/adapters'),
+          fetch('/sources')
+        ]);
+        if (!cfgRes.ok) throw new Error('Failed to load configuration');
+        if (!adaptersRes.ok) throw new Error('Failed to load adapters');
+        if (!sourcesRes.ok) throw new Error('Failed to load sources');
+        const config = await cfgRes.json();
+        const adapters = await adaptersRes.json();
+        const sources = await sourcesRes.json();
+        const adapterSelect = document.getElementById('adapter-select');
+        adapters.forEach(name => {
+          const opt = document.createElement('option');
+          opt.value = name;
+          opt.textContent = name;
+          adapterSelect.appendChild(opt);
+        });
+        if (config.adapter) adapterSelect.value = config.adapter;
+        const sourceSelect = document.getElementById('source-select');
+        sources.forEach(name => {
+          const opt = document.createElement('option');
+          opt.value = name;
+          opt.textContent = name;
+          sourceSelect.appendChild(opt);
+        });
+        if (config.source) sourceSelect.value = config.source;
+        document.querySelectorAll('input[name^="ORPHEUS_"]').forEach(input => {
+          const name = input.name;
+          if (config[name] !== undefined) {
+            input.value = config[name];
+          }
+        });
+        if (config.voice) {
+          const voiceName = typeof config.voice === 'object' ? config.voice.voice : config.voice;
+          const voiceInput = document.querySelector(`input[name="voice"][value="${voiceName}"]`);
+          if (voiceInput) {
+            voiceInput.checked = true;
+            document.querySelectorAll('.voice-card').forEach(c => c.classList.remove('active'));
+            const card = voiceInput.closest('.voice-card');
+            if (card) card.classList.add('active');
+          }
+        }
+      } catch (error) {
+        console.error('Error loading configuration:', error);
+      }
+    }
+
+    async function saveConfiguration() {
+      const configData = {};
+      document.querySelectorAll('input[name^="ORPHEUS_"]').forEach(input => {
+        configData[input.name] = input.value;
+      });
+      const selectedVoice = document.querySelector('input[name="voice"]:checked');
+      if (selectedVoice) configData.voice = selectedVoice.value;
+      const adapterSelect = document.getElementById('adapter-select');
+      if (adapterSelect && adapterSelect.value) configData.adapter = adapterSelect.value;
+      const sourceSelect = document.getElementById('source-select');
+      if (sourceSelect && sourceSelect.value) configData.source = sourceSelect.value;
+      try {
+        const response = await fetch('/config', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(configData)
+        });
+        if (!response.ok) throw new Error('Failed to save configuration');
+        const result = await response.json();
+        const statusElem = document.getElementById('config-status');
+        statusElem.textContent = result.message;
+        statusElem.classList.remove('hidden');
+        statusElem.classList.add('text-green-400');
+        setTimeout(() => { statusElem.classList.add('hidden'); }, 5000);
+      } catch (error) {
+        console.error('Error saving configuration:', error);
+        const statusElem = document.getElementById('config-status');
+        statusElem.textContent = 'Error saving configuration. Please try again.';
+        statusElem.classList.remove('hidden');
+        statusElem.classList.add('text-red-400');
+        setTimeout(() => { statusElem.classList.add('hidden'); }, 5000);
+      }
+    }
+
+    document.getElementById('save-config-btn').addEventListener('click', saveConfiguration);
+
+    initVoices();
+  });
+</script>
+
 </body>
 </html>

--- a/Morpheus_Client/server.py
+++ b/Morpheus_Client/server.py
@@ -25,7 +25,12 @@ from starlette.staticfiles import StaticFiles
 from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from .config import ensure_env_file_exists, get_current_config, save_config
-from .tts_engine import AVAILABLE_VOICES, DEFAULT_VOICE
+from .tts_engine import (
+    AVAILABLE_VOICES,
+    DEFAULT_VOICE,
+    VOICE_TO_LANGUAGE,
+    AVAILABLE_LANGUAGES,
+)
 from .tts_engine.adapter_registry import VoiceSchema, registry as adapter_registry
 from .tts_engine.inference import SAMPLE_RATE
 from .orchestrator.buffer import PlaybackBuffer
@@ -184,11 +189,19 @@ async def create_speech_api(request: Request) -> StreamingResponse:
 
 
 async def list_voices(request: Request) -> JSONResponse:  # pragma: no cover - simple
-    """Return list of available voices."""
+    """Return available voices and languages."""
 
     if not AVAILABLE_VOICES:
         raise HTTPException(status_code=404, detail="No voices available")
-    return JSONResponse({"status": "ok", "voices": AVAILABLE_VOICES})
+    return JSONResponse(
+        {
+            "status": "ok",
+            "voices": AVAILABLE_VOICES,
+            "languages": AVAILABLE_LANGUAGES,
+            "voice_to_language": VOICE_TO_LANGUAGE,
+            "default": DEFAULT_VOICE,
+        }
+    )
 
 
 async def tts_ws(websocket: WebSocket) -> None:

--- a/tests/test_admin_dynamic_voices.py
+++ b/tests/test_admin_dynamic_voices.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import asyncio
+from pathlib import Path
+import httpx
+
+# Ensure repo root on path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from Morpheus_Client import app
+from Morpheus_Client.tts_engine import AVAILABLE_VOICES
+import re
+
+
+def test_admin_voices_loaded_via_api():
+    html_path = Path(__file__).resolve().parents[1] / "Morpheus_Client" / "admin" / "tts.html"
+    html = html_path.read_text()
+
+    # Voices are populated at runtime; representative names should not appear
+    for voice in ("tara", "pierre"):
+        assert re.search(rf"\b{re.escape(voice)}\b", html) is None
+
+    # HTML should fetch voices dynamically
+    assert "fetch('/v1/audio/voices')" in html
+
+    async def fetch_voices():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.get("/v1/audio/voices")
+
+    resp = asyncio.run(fetch_voices())
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert "voices" in data and isinstance(data["voices"], list)
+    assert "languages" in data and isinstance(data["languages"], list)
+    assert "voice_to_language" in data and isinstance(data["voice_to_language"], dict)
+
+    first_voice = data["voices"][0]
+    assert first_voice in AVAILABLE_VOICES
+    assert data["voice_to_language"][first_voice] in data["languages"]


### PR DESCRIPTION
## WHY
- admin UI was server-templated so /admin assets were not strictly static

## OUTCOME
- voices and languages loaded at runtime via `/v1/audio/voices`
- `/admin` HTML free of Jinja templating and rendered client-side

## SURFACES TOUCHED
- `Morpheus_Client/server.py`
- `Morpheus_Client/admin/tts.html`
- `tests/test_admin_dynamic_voices.py`
- `GOALS.md`
- `DECISIONS.log`

## EXIT VIA SCENES
- `pytest`

## COMPATIBILITY
- `/v1/audio/voices` now returns voice-language mapping but retains original `voices` list

## NO-GO
- abort if `/v1/audio/voices` has no voices available

------
https://chatgpt.com/codex/tasks/task_e_68a4eb59ebc0832c9b4b47f860db9db1