### PR TITLE
feat: allow tuning inference parameters via config

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -332,3 +332,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** goal admin-voices-runtime
 
+### [2025-10-30] tunable-inference-params
+
+- **Context:** Operators need to tweak sampling settings without editing files or restarting.
+- **Decision:** `/config` accepts `ORPHEUS_TEMPERATURE`, `ORPHEUS_TOP_P`, and `ORPHEUS_MAX_TOKENS`, validates them, persists to `.env`, and updates inference globals.
+- **Alternatives:** Require manual `.env` edits followed by process restart.
+- **Trade-offs:** Defaults remain in memory for modules that snapshot values at import.
+- **Scope:** `Morpheus_Client/server.py`, `Morpheus_Client/tts_engine/inference.py`, `Morpheus_Client/admin/tts.html`, tests.
+- **Impact:** Sampling behaviour can be tuned at runtime and survives restarts via persisted config.
+- **TTL / Review:** revisit when more parameters or hot-reload of all modules is required.
+- **Status:** active
+- **Links:** goal tunable-inference-params
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -242,3 +242,15 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** `tests/test_admin_dynamic_voices.py::test_admin_voices_loaded_via_api`
 - **Linked Decisions:** [2025-08-19] admin-voices-runtime
 - **Notes:** initial load depends on voices endpoint availability
+
+### Capability: tunable-inference-params
+
+- **Purpose:** Allow operators to adjust sampling parameters without restart.
+- **Scope:** `/config` endpoint, inference module, admin UI form.
+- **Shape:** Posting `ORPHEUS_TEMPERATURE`, `ORPHEUS_TOP_P`, or `ORPHEUS_MAX_TOKENS` updates runtime behaviour and persists to `.env`.
+- **Compatibility:** falls back to defaults when unspecified.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `tests/test_config_generation_params.py::test_generation_param_round_trip`
+- **Linked Decisions:** [2025-10-30] tunable-inference-params
+- **Notes:** none

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -92,6 +92,7 @@
   - 2025-10-09: added GET and persistence via `.env`
   - 2025-10-24: allow `source_config` for constructor options
   - 2025-08-19: mirror config to `~/.morpheus/config` and load it before `.env`
+  - 2025-10-30: validate and persist `ORPHEUS_TEMPERATURE`, `ORPHEUS_TOP_P`, `ORPHEUS_MAX_TOKENS`
 
 ### Surface: admin-endpoint
 - **Type:** API

--- a/Morpheus_Client/admin/tts.html
+++ b/Morpheus_Client/admin/tts.html
@@ -202,19 +202,19 @@
                       <!-- Generation parameters -->
                       <div>
                         <label for="max_tokens" class="block text-xs font-medium text-white mb-1">Max Tokens</label>
-                        <input type="number" id="max_tokens" name="ORPHEUS_MAX_TOKENS" min="100" max="200000" step="1"
+                        <input type="number" id="max_tokens" name="ORPHEUS_MAX_TOKENS" min="100" max="200000" step="1" placeholder="8192"
                                class="block w-full rounded-md bg-dark-700 border-dark-600 text-white text-sm focus:border-primary-500 focus:ring-primary-500 focus:ring-offset-dark-800 px-3 py-2">
                       </div>
-                      
+
                       <div>
                         <label for="temperature" class="block text-xs font-medium text-white mb-1">Temperature</label>
-                        <input type="number" id="temperature" name="ORPHEUS_TEMPERATURE" min="0.1" max="1.5" step="0.1"
+                        <input type="number" id="temperature" name="ORPHEUS_TEMPERATURE" min="0.1" max="1.5" step="0.1" placeholder="0.6"
                                class="block w-full rounded-md bg-dark-700 border-dark-600 text-white text-sm focus:border-primary-500 focus:ring-primary-500 focus:ring-offset-dark-800 px-3 py-2">
                       </div>
-                      
+
                       <div>
                         <label for="top_p" class="block text-xs font-medium text-white mb-1">Top P</label>
-                        <input type="number" id="top_p" name="ORPHEUS_TOP_P" min="0.1" max="1" step="0.05"
+                        <input type="number" id="top_p" name="ORPHEUS_TOP_P" min="0.1" max="1" step="0.05" placeholder="0.9"
                                class="block w-full rounded-md bg-dark-700 border-dark-600 text-white text-sm focus:border-primary-500 focus:ring-primary-500 focus:ring-offset-dark-800 px-3 py-2">
                       </div>
                       

--- a/Morpheus_Client/tts_engine/inference.py
+++ b/Morpheus_Client/tts_engine/inference.py
@@ -83,6 +83,18 @@ except (ValueError, TypeError):
     print("WARNING: Invalid ORPHEUS_TOP_P value, using 0.9 as fallback")
     TOP_P = 0.9
 
+
+def update_generation_params(*, temperature=None, top_p=None, max_tokens=None) -> None:
+    """Update runtime generation parameters in-place."""
+
+    global TEMPERATURE, TOP_P, MAX_TOKENS
+    if temperature is not None:
+        TEMPERATURE = float(temperature)
+    if top_p is not None:
+        TOP_P = float(top_p)
+    if max_tokens is not None:
+        MAX_TOKENS = int(max_tokens)
+
 # Repetition penalty is hardcoded to 1.1 which is the only stable value for quality output
 REPETITION_PENALTY = 1.1
 

--- a/tests/test_config_generation_params.py
+++ b/tests/test_config_generation_params.py
@@ -1,0 +1,44 @@
+import asyncio
+import os
+
+import httpx
+import Morpheus_Client.server as server
+from Morpheus_Client.tts_engine import inference
+from Morpheus_Client.config import get_current_config
+
+
+def test_generation_param_round_trip():
+    orig_env = {k: os.environ.get(k) for k in ["ORPHEUS_TEMPERATURE", "ORPHEUS_TOP_P", "ORPHEUS_MAX_TOKENS"]}
+    orig_vals = (inference.TEMPERATURE, inference.TOP_P, inference.MAX_TOKENS)
+
+    async def run():
+        transport = httpx.ASGITransport(app=server.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            payload = {
+                "ORPHEUS_TEMPERATURE": 0.7,
+                "ORPHEUS_TOP_P": 0.8,
+                "ORPHEUS_MAX_TOKENS": 1234,
+            }
+            resp = await client.post("/config", json=payload)
+            assert resp.status_code == 200
+            cfg_resp = await client.get("/config")
+            return cfg_resp.json()
+
+    try:
+        config = asyncio.run(run())
+        assert float(config["ORPHEUS_TEMPERATURE"]) == 0.7
+        assert float(config["ORPHEUS_TOP_P"]) == 0.8
+        assert int(config["ORPHEUS_MAX_TOKENS"]) == 1234
+        assert inference.TEMPERATURE == 0.7
+        assert inference.TOP_P == 0.8
+        assert inference.MAX_TOKENS == 1234
+        assert get_current_config()["ORPHEUS_TEMPERATURE"] == "0.7"
+    finally:
+        for key, val in orig_env.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+        inference.update_generation_params(
+            temperature=orig_vals[0], top_p=orig_vals[1], max_tokens=orig_vals[2]
+        )


### PR DESCRIPTION
## Summary
- validate and persist ORPHEUS_TEMPERATURE, ORPHEUS_TOP_P, and ORPHEUS_MAX_TOKENS via `/config`
- propagate updated sampling parameters to the inference module
- expose temperature, top-p and max tokens controls in admin UI with test coverage

## Testing
- `pytest -q`

## Task
- **WHY:** operators need to tune inference sampling without restarts (goal: tunable-inference-params)
- **OUTCOME:** `/config` accepts temperature, top-p and max-tokens, applies them immediately, and persists values.
- **SURFACES TOUCHED:** `Morpheus_Client/server.py`, `Morpheus_Client/tts_engine/inference.py`, `Morpheus_Client/admin/tts.html`, `/config` API, tests
- **EXIT VIA SCENES:** `pytest -q`
- **COMPATIBILITY:** defaults preserved; missing fields fallback to existing values
- **NO-GO:** fail if parameters out of range or invalid types


------
https://chatgpt.com/codex/tasks/task_e_68a4f85be714832c95467deff9964527