### PR TITLE
docs: describe WAV streaming

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -368,3 +368,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** goal centralized-docs
 
+### [2025-08-24] default-audio-streaming
+
+- **Context:** `README.md` documented text streaming while the service and client stream WAV audio.
+- **Decision:** Use WAV audio streaming as the default and update documentation to match.
+- **Alternatives:** Rework the codebase to stream UTF-8 text instead of audio.
+- **Trade-offs:** Clients must handle binary data; switching to text would diverge from TTS functionality.
+- **Scope:** `README.md`.
+- **Impact:** Documentation reflects actual endpoints so integrators expect WAV output.
+- **TTL / Review:** Revisit if text streaming becomes a requirement.
+- **Status:** active
+- **Links:** goal centralized-docs
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -266,3 +266,4 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** n/a
 - **Linked Decisions:** consolidate-readmes
 - **Notes:** documents text-stream output and client/UI startup.
+- **Notes:** updated 2025-08-24 to describe WAV streaming endpoints.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 
 Single ASGI service exposing:
 
-- `POST /v1/text` – streams UTF-8 text chunks
+- `POST /v1/audio/speech` – streams WAV audio chunks
+- `GET /v1/audio/voices` – lists available voices
 - `GET /config` – returns current configuration
 - `POST /config` – updates adapter, voice, text source or env vars and persists
 - `GET /stats` – returns runtime telemetry and transcript history
 - `GET /admin` – serves operator dashboard
 
-The adapter registry defaults to a local text generator; remote backends are
-optional and reside in a separate module. Responses are streamed as text
-tokens rather than WAV files.
+The adapter registry defaults to a local speech synthesis adapter; remote backends are
+optional and reside in a separate module. Responses are streamed as WAV audio
+rather than text tokens.
 
 ## Installation
 
@@ -65,15 +66,16 @@ The service listens on `http://localhost:5005` and hosts the dashboard at
 `http://localhost:5005/admin`.
 
 ### Client
-Use the bundled client to consume streamed text:
+Use the bundled client to consume streamed audio:
 ```python
 import asyncio
 from Morpheus_Client import Client
 
 async def main():
     client = Client("http://localhost:5005")
-    async for chunk in client.stream_rest("Hello world"):
-        print(chunk.decode(), end="")
+    with open("output.wav", "wb") as f:
+        async for chunk in client.stream_rest("Hello world"):
+            f.write(chunk)
 
 asyncio.run(main())
 ```


### PR DESCRIPTION
### WHY
`centralized-docs` requires the README to reflect the service's actual streaming behavior. The file still described text tokens.

### OUTCOME
README now explains WAV streaming endpoints and client usage, and the decision log records audio as the default output.

### SURFACES TOUCHED
- `README.md`
- `DECISIONS.log`
- `GOALS.md`

### EXIT VIA SCENES
- `pytest -q`

### COMPATIBILITY
- Documentation only; runtime remains unchanged.

### NO-GO
- Abort if required test dependencies cannot be installed.


------
https://chatgpt.com/codex/tasks/task_e_68ab1548ca00832c9807921b457276bf