### PR TITLE
docs: clarify admin UI is static

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -392,3 +392,14 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** goal centralized-docs
 
+### [2025-08-24] static-admin-ui
+
+- **Context:** `README.md` implied the admin dashboard required a Node.js build.
+- **Decision:** Document the dashboard as purely static HTML with no Node tooling.
+- **Alternatives:** Introduce a `package.json` and build pipeline for the admin UI.
+- **Trade-offs:** Forgoing tooling keeps the UI simple but limits future enhancements.
+- **Scope:** `README.md`.
+- **Impact:** Reduces setup steps and external dependencies.
+- **TTL / Review:** Revisit if the dashboard gains dynamic features.
+- **Status:** active
+- **Links:** goal centralized-docs

--- a/README.md
+++ b/README.md
@@ -50,12 +50,8 @@ pip install orpheus-cpp
 
 This dependency is pinned in `requirements.txt`; the build step may take several minutes.
 
-### UI build
-To build the optional web UI, install Node.js and npm then run within the UI directory (for example `Morpheus_Client/admin`):
-```bash
-npm install
-npm run build
-```
+### Admin UI
+The dashboard under `Morpheus_Client/admin` is served directly as static HTML. No Node.js tools or build step are required.
 
 ### Run
 Start the server and open the admin UI:


### PR DESCRIPTION
## Task
- **WHY:** README suggested a Node.js build step for the admin dashboard; align docs with goal `centralized-docs`.
- **OUTCOME:** Admin UI documented as static HTML requiring no Node tooling.
- **SURFACES TOUCHED:** `README.md`, `DECISIONS.log`
- **EXIT VIA SCENES:** `pytest`
- **COMPATIBILITY:** Documentation-only; no runtime impact.
- **NO-GO:** abort if tests fail.

## Summary
- document the admin dashboard as a static UI served from `Morpheus_Client/admin`
- record decision to forgo Node tooling for the admin UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab2c389d7c832cb77b46f68f0f4b1c