### PR TITLE
docs: clarify orpheus-cpp install

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -19,6 +19,18 @@
 
 _(New entries go on top. Keep each under ~20 lines.)_
 
+### [2025-11-07] orpheus-cpp-docs
+
+- **Context:** Installation instructions duplicated manual `orpheus-cpp` steps despite the dependency being pinned in `requirements.txt`.
+- **Decision:** Keep `orpheus-cpp` in `requirements.txt` and document C++ build prerequisites prior to running `pip install -r requirements.txt`.
+- **Alternatives:** Drop the package from the requirements and require a standalone install.
+- **Trade-offs:** Users must prepare a C++ toolchain before installing dependencies.
+- **Scope:** `README.md`, `DECISIONS.log`.
+- **Impact:** Clearer install flow and avoids redundant package commands.
+- **TTL / Review:** Revisit if prebuilt wheels land or another default adapter is chosen.
+- **Status:** ACTIVE
+- **Links:** goal orpheus-cpp-startup-check
+
 ### [2025-11-06] trim-requirements
 
 - **Context:** `requirements.txt` carried numerous training and UI dependencies unused by the Morpheus client/server.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ rather than text tokens.
 
 ### Prerequisites
 - Python 3.8–3.11
+- C++17 toolchain and CMake for `orpheus-cpp` (e.g. `sudo apt install build-essential cmake` on Linux or [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) on Windows)
 - Optional UI: Node.js ≥18 and npm
 
 ### Base setup
+Ensure the build tools above are installed, then:
 ```bash
 pip install -r requirements.txt
 ```
@@ -41,14 +43,7 @@ pip install -r requirements.txt
   pip install torch==2.2.0
   ```
 
-### C++ bindings
-The local streaming adapter uses `orpheus_cpp`, which builds a native extension. Ensure a C++17 toolchain and CMake are available (e.g. `sudo apt install build-essential cmake` on Linux or [Visual Studio Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) on Windows) before installing:
-
-```bash
-pip install orpheus-cpp
-```
-
-This dependency is pinned in `requirements.txt`; the build step may take several minutes.
+> `orpheus-cpp` is pinned in `requirements.txt` and builds a native extension; the build step may take several minutes.
 
 ### Admin UI
 The dashboard under `Morpheus_Client/admin` is served directly as static HTML. No Node.js tools or build step are required.


### PR DESCRIPTION
## WHY
- `requirements.txt` already pins `orpheus-cpp`, but the README suggested installing it separately, leaving build prerequisites unclear.

## OUTCOME
- Installation docs instruct preparing a C++17 toolchain and running `pip install -r requirements.txt` once.
- Logged decision to keep `orpheus-cpp` in `requirements.txt` and document prerequisites.

## SURFACES TOUCHED
- `README.md`
- `DECISIONS.log`

## EXIT VIA SCENES
- `pytest`

## COMPATIBILITY
- No runtime behavior change; installs still require a functional C++ toolchain.

## NO-GO
- Abort if `pip install -r requirements.txt` fails due to missing build tooling.

------
https://chatgpt.com/codex/tasks/task_e_68ab2daa8384832ca680d7ad4faa58f8