### PR TITLE
docs: add quick start with venv setup

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -415,3 +415,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** Revisit if the dashboard gains dynamic features.
 - **Status:** active
 - **Links:** goal centralized-docs
+
+### [2025-08-24] quick-start-docs
+
+- **Context:** The README lacked guidance on creating a virtual environment and mentioned no one-command bootstrap option.
+- **Decision:** Add a Quick Start section documenting virtual environment setup and reference the `scripts/one_click.py` bootstrap script.
+- **Alternatives:** Leave installation instructions as-is without highlighting environment isolation.
+- **Trade-offs:** Additional documentation requires upkeep as setup scripts evolve.
+- **Scope:** `README.md`, `DECISIONS.log`.
+- **Impact:** New contributors can isolate dependencies quickly and discover the one-click setup path.
+- **TTL / Review:** Revisit if the bootstrap process changes or a `bootstrap.sh` replaces `one_click.py`.
+- **Status:** active
+- **Links:** goal centralized-docs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,25 @@ The adapter registry defaults to a local speech synthesis adapter; remote backen
 optional and reside in a separate module. Responses are streamed as WAV audio
 rather than text tokens.
 
+## Quick Start
+
+Create and activate a virtual environment before installing dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+pip install -r requirements.txt
+python scripts/start.py
+```
+
+Prefer a one-command setup? Run the bootstrap script:
+
+```bash
+python scripts/one_click.py
+```
+
+This downloads Miniforge if needed and installs all requirements.
+
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
## Task
- **WHY:** clarify environment setup in README to support goal `centralized-docs`.
- **OUTCOME:** Quick Start section shows virtual environment creation and mentions `scripts/one_click.py` for one-command installs.
- **SURFACES TOUCHED:** `README.md`, `DECISIONS.log`
- **EXIT VIA SCENES:** `scripts/run_tests.sh` *(fails: missing Orpheus-TTS)*, `pytest -q` *(fails: missing httpx, numpy)*
- **COMPATIBILITY:** documentation only; no runtime impact
- **NO-GO:** abort if setup scripts begin mutating repository files


------
https://chatgpt.com/codex/tasks/task_e_68ab2f230e54832c993283db93a17129