### PR TITLE
docs: rebuild setup instructions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,3 +7,4 @@ Capability-level changes between releases. Focus on user-facing deltas, not comm
 - CLI now returns meaningful exit codes, enabling shell automation.
 - Editing utilities avoid creating directories that already exist.
 - Removed unused requirements and made `sounddevice` optional for server startup.
+- Rewrote README with explicit virtual environment and one-click bootstrap instructions.

--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -427,3 +427,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** Revisit if the bootstrap process changes or a `bootstrap.sh` replaces `one_click.py`.
 - **Status:** active
 - **Links:** goal centralized-docs
+
+### [2025-08-24] fresh-readme-setup
+
+- **Context:** The existing README was removed; users needed a concise guide to install dependencies and run the TTS service.
+- **Decision:** Recreate the README with manual and one-click install paths, hardware-specific Torch guidance, and a CLI verification step.
+- **Alternatives:** Incrementally patch the previous README.
+- **Trade-offs:** A fresh document must be kept in sync with setup scripts.
+- **Scope:** `README.md`, `CHANGES.md`, `DECISIONS.log`.
+- **Impact:** Users can follow a single set of instructions to launch Morpheus and verify audio streaming.
+- **TTL / Review:** Revisit when setup flows change or text streaming replaces audio.
+- **Status:** active
+- **Links:** goal centralized-docs

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Project Morpheus
+
+ASGI service that converts text input into streamed WAV audio using the Orpheus TTS engine.
+
+## Quick Start
+
+### Manual setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+
+# install the Torch build for your hardware BEFORE other requirements
+# NVIDIA CUDA
+pip install torch==2.2.0 --extra-index-url https://download.pytorch.org/whl/cu124
+pip install bitsandbytes==0.46.1 flash-attn==2.7.4.post1
+# AMD ROCm
+# pip install torch==2.2.0 --extra-index-url https://download.pytorch.org/whl/rocm6.2
+# CPU only
+# pip install torch==2.2.0
+
+pip install -r requirements.txt
+python scripts/start.py
+```
+
+After the server prints that it is running, verify audio streaming:
+
+```bash
+curl -L -X POST http://localhost:5005/v1/audio/speech \
+     -H "Content-Type: text/plain" \
+     --data 'Hello world' -o output.wav
+```
+
+Play `output.wav` with any media player.
+
+### One-click setup
+
+```bash
+python scripts/one_click.py
+python scripts/start.py
+```
+
+`one_click.py` downloads Miniforge if needed, creates a virtual environment and installs all requirements.
+
+The admin dashboard is served at http://localhost:5005/admin.
+
+## Prerequisites
+
+- Python 3.8–3.11
+- C++17 toolchain and CMake for building `orpheus-cpp` (e.g. `sudo apt install build-essential cmake`)
+- The `orpheus-cpp` build step during installation may take several minutes.
+
+## Client example
+
+```python
+import asyncio
+from Morpheus_Client import Client
+
+async def main():
+    client = Client("http://localhost:5005")
+    with open("output.wav", "wb") as f:
+        async for chunk in client.stream_rest("Hello world"):
+            f.write(chunk)
+
+asyncio.run(main())
+```


### PR DESCRIPTION
### WHY
Provide a clean README so newcomers can install dependencies and launch the Morpheus TTS service without confusion, supporting goal `centralized-docs`.

### OUTCOME
A single README describes manual and one-click setup, hardware-specific Torch installs, and a curl-based audio check.

### SURFACES TOUCHED
- `README.md`
- `CHANGES.md`
- `DECISIONS.log`

### EXIT VIA SCENES
- `python -m pytest -q`

### COMPATIBILITY
Documentation only; runtime behaviour unchanged.

### NO-GO
Stop if tests fail.


------
https://chatgpt.com/codex/tasks/task_e_68aac5ec94e8832c8a623f7b112b94ae