### PR TITLE
docs: rebuild setup instructions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,3 +7,5 @@ Capability-level changes between releases. Focus on user-facing deltas, not comm
 - CLI now returns meaningful exit codes, enabling shell automation.
 - Editing utilities avoid creating directories that already exist.
 - Removed unused requirements and made `sounddevice` optional for server startup.
+- Rewrote README with explicit virtual environment and one-click bootstrap instructions.
+- `scripts/start.py` now injects the project root into `sys.path` so `Morpheus_Client` imports even when run from other directories.

--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -427,3 +427,27 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** Revisit if the bootstrap process changes or a `bootstrap.sh` replaces `one_click.py`.
 - **Status:** active
 - **Links:** goal centralized-docs
+
+### [2025-08-24] fresh-readme-setup
+
+- **Context:** The existing README was removed; users needed a concise guide to install dependencies and run the TTS service.
+- **Decision:** Recreate the README with manual and one-click install paths, hardware-specific Torch guidance, and a CLI verification step.
+- **Alternatives:** Incrementally patch the previous README.
+- **Trade-offs:** A fresh document must be kept in sync with setup scripts.
+- **Scope:** `README.md`, `CHANGES.md`, `DECISIONS.log`.
+- **Impact:** Users can follow a single set of instructions to launch Morpheus and verify audio streaming.
+- **TTL / Review:** Revisit when setup flows change or text streaming replaces audio.
+- **Status:** active
+- **Links:** goal centralized-docs
+
+### [2025-08-24] start-path-guard
+
+- **Context:** Running `scripts/start.py` from outside the project root raised `ModuleNotFoundError: No module named 'Morpheus_Client'`.
+- **Decision:** Prepend the repository root to `sys.path` at startup and note the root requirement in the README.
+- **Alternatives:** Require users to run the script from the project root or install the package separately.
+- **Trade-offs:** Adds a few lines of bootstrap code but prevents common import errors.
+- **Scope:** `scripts/start.py`, `README.md`.
+- **Impact:** `scripts/start.py` works from any directory and documentation warns users to ensure the repo root is on `PYTHONPATH`.
+- **TTL / Review:** Revisit if the project becomes an installable package.
+- **Status:** active
+- **Links:** goal centralized-docs

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# Project Morpheus
+
+ASGI service that converts text input into streamed WAV audio using the Orpheus TTS engine.
+
+## Quick Start
+
+All commands assume the current working directory is the project root.
+
+### Manual setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
+
+# install the Torch build for your hardware BEFORE other requirements
+# NVIDIA CUDA
+pip install torch==2.2.0 --extra-index-url https://download.pytorch.org/whl/cu124
+pip install bitsandbytes==0.46.1 flash-attn==2.7.4.post1
+# AMD ROCm
+# pip install torch==2.2.0 --extra-index-url https://download.pytorch.org/whl/rocm6.2
+# CPU only
+# pip install torch==2.2.0
+
+pip install -r requirements.txt
+python scripts/start.py
+```
+
+After the server prints that it is running, verify audio streaming:
+
+```bash
+curl -L -X POST http://localhost:5005/v1/audio/speech \
+     -H "Content-Type: text/plain" \
+     --data 'Hello world' -o output.wav
+```
+
+Play `output.wav` with any media player.
+
+### One-click setup
+
+```bash
+python scripts/one_click.py
+python scripts/start.py
+```
+
+`one_click.py` downloads Miniforge if needed, creates a virtual environment and installs all requirements.
+
+The admin dashboard is served at http://localhost:5005/admin.
+
+## Prerequisites
+
+- Python 3.8–3.11
+- C++17 toolchain and CMake for building `orpheus-cpp` (e.g. `sudo apt install build-essential cmake`)
+- The `orpheus-cpp` build step during installation may take several minutes.
+
+## Client example
+
+```python
+import asyncio
+from Morpheus_Client import Client  # repo root must be on PYTHONPATH
+
+async def main():
+    client = Client("http://localhost:5005")
+    with open("output.wav", "wb") as f:
+        async for chunk in client.stream_rest("Hello world"):
+            f.write(chunk)
+
+asyncio.run(main())
+```

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -1,6 +1,14 @@
 import os
+import sys
 import threading
 import webbrowser
+from pathlib import Path
+
+# Ensure repository root on sys.path so `Morpheus_Client` is importable
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 from dotenv import load_dotenv
 from Morpheus_Client.config import ensure_env_file_exists
 from Morpheus_Client import start_server


### PR DESCRIPTION
### WHY
Provide a clean README so newcomers can install dependencies and launch the Morpheus TTS service without confusion, supporting goal `centralized-docs`.

### OUTCOME
- A single README describes manual and one-click setup, hardware-specific Torch installs, and a curl-based audio check.
- `scripts/start.py` adds the project root to `sys.path` so `Morpheus_Client` imports succeed even when the script is launched from another directory.

### SURFACES TOUCHED
- `README.md`
- `scripts/start.py`
- `CHANGES.md`
- `DECISIONS.log`

### EXIT VIA SCENES
- `python -m pytest -q`

### COMPATIBILITY
Documentation and bootstrap improvements; runtime behaviour unchanged aside from more robust path handling.

### NO-GO
Stop if tests fail.


------
https://chatgpt.com/codex/tasks/task_e_68aac5ec94e8832c8a623f7b112b94ae