### PR TITLE
Handle existing Miniforge installs in setup script

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -19,6 +19,18 @@
 
 _(New entries go on top. Keep each under ~20 lines.)_
 
+### [2025-08-24] miniforge-idempotent
+
+- **Context:** `scripts/one_click.py` attempted a fresh Miniforge install even when the target directory already existed.
+- **Decision:** Detect existing `miniforge3` directories and skip installer execution to make setup idempotent.
+- **Alternatives:** Always run the installer with an update flag; rely solely on `conda` being on `PATH`.
+- **Trade-offs:** Skipping avoids unintended reinstalls but forgoes automatic updates.
+- **Scope:** `scripts/one_click.py`.
+- **Impact:** Re-running the setup script exits cleanly when Miniforge is present.
+- **TTL / Review:** Revisit if Miniforge offers a cross-platform update mode.
+- **Status:** ACTIVE
+- **Links:** goal idempotent-miniforge-setup
+
 ### [2025-11-07] orpheus-cpp-docs
 
 - **Context:** Installation instructions duplicated manual `orpheus-cpp` steps despite the dependency being pinned in `requirements.txt`.

--- a/GOALS.md
+++ b/GOALS.md
@@ -267,3 +267,15 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Decisions:** consolidate-readmes
 - **Notes:** documents text-stream output and client/UI startup.
 - **Notes:** updated 2025-08-24 to describe WAV streaming endpoints.
+
+### Capability: idempotent-miniforge-setup
+
+- **Purpose:** Avoid reinstalling Miniforge when running the environment setup multiple times.
+- **Scope:** `scripts/one_click.py`.
+- **Shape:** Presence of `miniforge3` directory or `conda` binary results in a no-op.
+- **Compatibility:** no flags; existing installations remain untouched.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** tests/test_one_click.py::test_miniforge_detection_and_skip
+- **Linked Decisions:** [2025-08-24] miniforge-idempotent
+- **Notes:** re-evaluate if update-through-installer is required

--- a/scripts/one_click.py
+++ b/scripts/one_click.py
@@ -10,8 +10,13 @@ import tempfile
 import urllib.request
 from pathlib import Path
 
+
 def miniforge_installed() -> bool:
-    return shutil.which("conda") is not None
+    """Return True if a Miniforge installation is detected."""
+    if shutil.which("conda") is not None:
+        return True
+    home = Path.home()
+    return any((home / name).exists() for name in ("miniforge3", "Miniforge3"))
 
 def detect_platform() -> tuple[str, str]:
     system = platform.system().lower()
@@ -34,6 +39,10 @@ def detect_platform() -> tuple[str, str]:
 
 def install_miniforge(os_name: str, arch: str) -> None:
     ext = "exe" if os_name == "Windows" else "sh"
+    target = Path.home() / ("Miniforge3" if os_name == "Windows" else "miniforge3")
+    if target.exists():
+        print(f"Miniforge already installed at {target}")
+        return
     url = (
         "https://github.com/conda-forge/miniforge/releases/latest/download/"
         f"Miniforge3-{os_name}-{arch}.{ext}"
@@ -43,7 +52,6 @@ def install_miniforge(os_name: str, arch: str) -> None:
         installer = Path(tmp) / f"miniforge.{ext}"
         urllib.request.urlretrieve(url, installer)
         if os_name == "Windows":
-            target = Path.home() / "miniforge3"
             subprocess.check_call([str(installer), "/S", f"/D={target}"])
         else:
             installer.chmod(0o755)

--- a/tests/test_one_click.py
+++ b/tests/test_one_click.py
@@ -1,0 +1,13 @@
+import shutil
+from pathlib import Path
+
+from scripts import one_click
+
+
+def test_miniforge_detection_and_skip(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    (tmp_path / "miniforge3").mkdir()
+    assert one_click.miniforge_installed() is True
+    # Should exit early without attempting download
+    one_click.install_miniforge("Linux", "x86_64")


### PR DESCRIPTION
### WHY
Rerunning `scripts/one_click.py` attempted to reinstall Miniforge even when it was already present, leading to errors.

### OUTCOME
The setup script now detects existing Miniforge directories and skips the installer, allowing repeated runs to complete cleanly.

### SURFACES TOUCHED
- `scripts/one_click.py`
- `tests/test_one_click.py`
- `GOALS.md`
- `DECISIONS.log`

### EXIT VIA SCENES
- `pytest tests/test_one_click.py -q`
- `pytest -q`

### COMPATIBILITY
No flags or migrations; existing Miniforge installs are left untouched.

### NO-GO
Abort if the Miniforge download fails when no installation is present.

------
https://chatgpt.com/codex/tasks/task_e_68ab36e68cc4832c93d3e0f9d98e2ccd