### PR TITLE
fix start script module path

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -439,3 +439,14 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** Revisit when setup flows change or text streaming replaces audio.
 - **Status:** active
 - **Links:** goal centralized-docs
+### [2025-08-24] start-path-prepend
+
+- **Context:** Running `scripts/start.py` directly failed because the repository root wasn't on `sys.path`.
+- **Decision:** Prepend the repository root to `sys.path` within `scripts/start.py`.
+- **Alternatives:** Require launching via `python -m` or packaging the project.
+- **Trade-offs:** Adds a small path tweak but avoids packaging overhead.
+- **Scope:** `scripts/start.py`.
+- **Impact:** The start script can import `Morpheus_Client` without installation.
+- **TTL / Review:** Revisit if the project becomes an installable package.
+- **Status:** active
+- **Links:** n/a

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -1,3 +1,10 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 import os
 import threading
 import webbrowser


### PR DESCRIPTION
## Summary
- ensure `scripts/start.py` prepends the repo root to `sys.path` so `Morpheus_Client` imports succeed
- document the path fix in `DECISIONS.log`

## Testing
- `python -c "import scripts.start"`
- `pytest -q`

## Task
- **WHY:** running the startup script directly failed to find project modules (goal: auto-start-config)
- **OUTCOME:** `scripts/start.py` bootstraps `sys.path` with the repo root, enabling imports
- **SURFACES TOUCHED:** `scripts/start.py`, `DECISIONS.log`
- **EXIT VIA SCENES:** `pytest -q`
- **COMPATIBILITY:** no migrations or flags
- **NO-GO:** failing tests


------
https://chatgpt.com/codex/tasks/task_e_68ab36e50db8832c99eb74c0dac82c8c