### PR TITLE
fix: send input field in admin TTS form

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -474,3 +474,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** Revisit if the project becomes an installable package.
 - **Status:** active
 - **Links:** n/a
+
+### [2025-09-06] admin-input-field
+
+- **Context:** The admin UI sent `{text,...}` to `/v1/audio/speech`, but the API expects an `input` field, leading to HTTP 400 responses.
+- **Decision:** Send `{input,...}` in the request body and rename the textarea `id`/`name` to `input` to mirror the API.
+- **Alternatives:** Adjust the API to accept `text` or handle both fields.
+- **Trade-offs:** Updating the UI avoids expanding server input validation while touching only client code.
+- **Scope:** `Morpheus_Client/admin/index.html`.
+- **Impact:** Admin submissions now conform to the API and generate audio instead of 400 errors.
+- **TTL / Review:** Revisit if the speech endpoint schema changes.
+- **Status:** active
+- **Links:** n/a

--- a/Morpheus_Client/admin/index.html
+++ b/Morpheus_Client/admin/index.html
@@ -110,12 +110,12 @@
               
               <!-- Text input -->
               <div class="mb-6">
-                <label for="text" class="block text-sm font-medium text-white mb-1">Text to speak</label>
+                <label for="input" class="block text-sm font-medium text-white mb-1">Text to speak</label>
                 <div class="relative">
-                  <textarea 
-                    name="text" 
-                    id="text" 
-                    rows="4" 
+                  <textarea
+                    name="input"
+                    id="input"
+                    rows="4"
                     maxlength="8192"
                     class="block w-full rounded-md border-dark-600 bg-dark-700 text-white shadow-sm focus:border-primary-500 focus:ring-primary-500 focus:ring-offset-dark-800 sm:text-sm px-3 py-2"
                     placeholder="Enter text to convert to speech..."
@@ -357,7 +357,7 @@
 <script>
   document.addEventListener('DOMContentLoaded', function() {
     let wavesurfer;
-    const textArea = document.getElementById('text');
+    const textArea = document.getElementById('input');
     const charCount = document.getElementById('char-count');
 
     textArea.addEventListener('input', () => {
@@ -522,7 +522,7 @@
         const response = await fetch('/v1/audio/speech', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ text, voice: voiceInput.value })
+          body: JSON.stringify({ input: text, voice: voiceInput.value })
         });
         if (!response.ok) throw new Error('Failed to generate speech');
         const data = await response.json();


### PR DESCRIPTION
## Task
- **WHY:** admin panel returns 400 because it posts `{text}` to `/v1/audio/speech` while the API expects `{input}`
- **OUTCOME:** submitting the form sends `{input: ..., voice: ...}` and the server replies with audio
- **SURFACES TOUCHED:** `Morpheus_Client/admin/index.html`
- **EXIT VIA SCENES:** `pytest`
- **COMPATIBILITY:** UI change only; server contract unchanged
- **NO-GO:** failing tests or 400 responses from `/v1/audio/speech`

## Summary
- rename admin textarea to `input` and post `{input, voice}`
- document decision in `DECISIONS.log`

## Testing
- `pytest`
- start server and `curl -X POST localhost:8000/v1/audio/speech -d '{"text":"hello"}'` (400)
- `curl -X POST localhost:8000/v1/audio/speech -d '{"input":"hello"}'` (200, wav)


------
https://chatgpt.com/codex/tasks/task_e_68ab3e51d390832c91ce5fafeeb1c18d