### PR TITLE
Gracefully stop local TTS stream on sentinel

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -19,6 +19,18 @@
 
 _(New entries go on top. Keep each under ~20 lines.)_
 
+### [2025-08-24] orpheus-local-none-stop
+
+- **Context:** `_stream_from_model` assumed the underlying iterator raised `StopIteration`; some `orpheus_cpp` iterators instead returned `None`, causing `TypeError` during unpacking.
+- **Decision:** Invoke `next` with a `None` sentinel inside a thread and break when `None` is returned, avoiding unpacking errors.
+- **Alternatives:** Keep try/except expecting `StopIteration`.
+- **Trade-offs:** Adapts to nonconformant iterators at the cost of deviating from the generator protocol.
+- **Scope:** `Morpheus_Client/tts_engine/orpheus_local.py`, tests.
+- **Impact:** Local TTS streaming terminates cleanly when the model signals completion by returning `None`.
+- **TTL / Review:** Revisit if upstream iterator behavior changes.
+- **Status:** ACTIVE
+- **Links:** test_stream_from_model_none_termination
+
 ### [2025-11-24] admin-index-default
 
 - **Context:** The admin dashboard HTML lived at `tts.html`, so navigating to `/admin/` yielded a 404 unless the file name was specified.

--- a/Morpheus_Client/tts_engine/orpheus_local.py
+++ b/Morpheus_Client/tts_engine/orpheus_local.py
@@ -67,10 +67,10 @@ async def _stream_from_model(
 
     gen = model.stream_tts_sync(prompt, options={"voice_id": voice})
     while True:
-        try:
-            _sr, chunk = await asyncio.to_thread(next, gen)
-        except StopIteration:
+        result = await asyncio.to_thread(lambda: next(gen, None))
+        if result is None:
             break
+        _sr, chunk = result
         yield chunk.tobytes()
 
 

--- a/tests/test_stream_from_model_none_termination.py
+++ b/tests/test_stream_from_model_none_termination.py
@@ -1,0 +1,51 @@
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+# Stub optional dependency to avoid import errors
+sys.modules.setdefault("sounddevice", types.SimpleNamespace())
+
+import asyncio
+
+from Morpheus_Client.tts_engine.orpheus_local import _stream_from_model
+
+
+class DummyChunk:
+    def __init__(self, data: bytes) -> None:
+        self._data = data
+
+    def tobytes(self) -> bytes:
+        return self._data
+
+
+class NoneTerminatingIterator:
+    def __init__(self) -> None:
+        self._items = [
+            (16000, DummyChunk(b"a")),
+            (16000, DummyChunk(b"b")),
+        ]
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._items:
+            return self._items.pop(0)
+        return None
+
+
+class DummyModel:
+    def stream_tts_sync(self, *_: object, **__: object):
+        return NoneTerminatingIterator()
+
+def test_stream_from_model_stops_on_none():
+    model = DummyModel()
+
+    async def run():
+        gen = _stream_from_model(model, "hi", "voice")
+        return [pcm async for pcm in gen]
+
+    chunks = asyncio.run(run())
+    assert chunks == [b"a", b"b"]


### PR DESCRIPTION
### Summary
- handle generators that return `None` when exhausted in `orpheus_local._stream_from_model`
- cover termination sentinel with a dedicated test
- log decision about supporting nonconformant iterator end signals

### Testing
- `pytest tests/test_stream_from_model_none_termination.py -q`

### Task
- **WHY:** prevent TypeError when the local TTS generator returns `None` instead of raising `StopIteration`
- **OUTCOME:** local TTS streaming halts cleanly on a `None` sentinel and is covered by a regression test
- **SURFACES TOUCHED:** `Morpheus_Client/tts_engine/orpheus_local.py`, `tests/test_stream_from_model_none_termination.py`, `DECISIONS.log`
- **EXIT VIA SCENES:** `tests/test_stream_from_model_none_termination.py`
- **COMPATIBILITY:** no interface changes or migrations
- **NO-GO:** none identified


------
https://chatgpt.com/codex/tasks/task_e_68ab422a41a0832c93802e97996616e4