### PR TITLE
feat: auto-create venv in one-click setup

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -19,6 +19,18 @@
 
 _(New entries go on top. Keep each under ~20 lines.)_
 
+### [2025-08-24] one-click-venv
+
+- **Context:** Dependency installation previously used the system Python and assumed a pre-existing virtual environment.
+- **Decision:** Ensure `.venv` is created if missing and use its Python when installing requirements.
+- **Alternatives:** Require manual environment creation; continue using `sys.executable` directly.
+- **Trade-offs:** Adds setup steps but yields isolated and reproducible environments.
+- **Scope:** `scripts/one_click.py`, `tests/test_one_click.py`.
+- **Impact:** One-click setup now bootstraps a dedicated virtualenv for dependency installation.
+- **TTL / Review:** Reassess if distribution shifts to packaged installers.
+- **Status:** ACTIVE
+- **Links:** auto-venv-setup
+
 ### [2025-08-24] orpheus-local-none-stop
 
 - **Context:** `_stream_from_model` assumed the underlying iterator raised `StopIteration`; some `orpheus_cpp` iterators instead returned `None`, causing `TypeError` during unpacking.

--- a/GOALS.md
+++ b/GOALS.md
@@ -279,3 +279,17 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** tests/test_one_click.py::test_miniforge_detection_and_skip
 - **Linked Decisions:** [2025-08-24] miniforge-idempotent
 - **Notes:** re-evaluate if update-through-installer is required
+
+### Capability: auto-venv-setup
+
+- **Purpose:** Ensure one-click script initializes and uses a dedicated virtual environment.
+- **Scope:** `scripts/one_click.py`, `tests/test_one_click.py`.
+- **Shape:** `.venv` is created if missing and dependency installation uses its Python executable.
+- **Compatibility:** additive; existing `.venv` remains untouched.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:**
+  - `tests/test_one_click.py::test_ensure_venv_creates_and_returns_python`
+  - `tests/test_one_click.py::test_install_requirements_uses_given_python`
+- **Linked Decisions:** [2025-08-24] one-click-venv
+- **Notes:** remind users to activate the virtual environment before starting the server

--- a/scripts/one_click.py
+++ b/scripts/one_click.py
@@ -61,16 +61,26 @@ def install_miniforge(os_name: str, arch: str) -> None:
 def pick_requirements() -> Path:
     return Path(__file__).resolve().parent.parent / "requirements.txt"
 
-def install_requirements(req_file: Path) -> None:
+def ensure_venv() -> Path:
+    venv_dir = Path(".venv")
+    if not venv_dir.exists():
+        subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)])
+    if platform.system().lower() == "windows":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+def install_requirements(python: Path, req_file: Path) -> None:
     print(f"Installing dependencies from {req_file}")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(req_file)])
+    subprocess.check_call([str(python), "-m", "pip", "install", "-r", str(req_file)])
 
 def main() -> None:
     if not miniforge_installed():
         os_name, arch = detect_platform()
         install_miniforge(os_name, arch)
     req_file = pick_requirements()
-    install_requirements(req_file)
+    python = ensure_venv()
+    install_requirements(python, req_file)
+    print("Setup complete. Run 'source .venv/bin/activate' before launching the server.")
 
 if __name__ == "__main__":
     main()

--- a/tests/test_one_click.py
+++ b/tests/test_one_click.py
@@ -1,4 +1,6 @@
+import platform
 import shutil
+import sys
 from pathlib import Path
 
 from scripts import one_click
@@ -11,3 +13,32 @@ def test_miniforge_detection_and_skip(tmp_path, monkeypatch):
     assert one_click.miniforge_installed() is True
     # Should exit early without attempting download
     one_click.install_miniforge("Linux", "x86_64")
+
+
+def test_ensure_venv_creates_and_returns_python(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_call(cmd):
+        calls.append(cmd)
+        (tmp_path / ".venv").mkdir()
+
+    monkeypatch.setattr(one_click.subprocess, "check_call", fake_call)
+    python = one_click.ensure_venv()
+    assert calls[0][:3] == [sys.executable, "-m", "venv"]
+    expected = Path(".venv") / ("Scripts" if platform.system().lower() == "windows" else "bin") / ("python.exe" if platform.system().lower() == "windows" else "python")
+    assert python == expected
+
+
+def test_install_requirements_uses_given_python(tmp_path, monkeypatch):
+    req = tmp_path / "requirements.txt"
+    req.write_text("")
+    calls = []
+
+    def fake_call(cmd):
+        calls.append(cmd)
+
+    monkeypatch.setattr(one_click.subprocess, "check_call", fake_call)
+    python = tmp_path / "custom" / "python"
+    one_click.install_requirements(python, req)
+    assert calls[0][0] == str(python)


### PR DESCRIPTION
## WHY
- streamline environment setup by ensuring a dedicated virtual environment exists before installing dependencies

## OUTCOME
- `scripts/one_click.py` creates `.venv` when missing and installs requirements using its Python, reminding users to activate it

## SURFACES TOUCHED
- `scripts/one_click.py`
- `tests/test_one_click.py`
- `GOALS.md`
- `DECISIONS.log`

## EXIT VIA SCENES
- `tests/test_one_click.py::test_miniforge_detection_and_skip`
- `tests/test_one_click.py::test_ensure_venv_creates_and_returns_python`
- `tests/test_one_click.py::test_install_requirements_uses_given_python`

## COMPATIBILITY
- additive; existing `.venv` directories and system Pythons remain unaffected

## NO-GO
- abort if `.venv` creation or pip installation fails


------
https://chatgpt.com/codex/tasks/task_e_68ab47814d88832cbdd6e33029acbbfa