### PR TITLE
feat: auto-install GPU dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,3 +8,4 @@ Capability-level changes between releases. Focus on user-facing deltas, not comm
 - Editing utilities avoid creating directories that already exist.
 - Removed unused requirements and made `sounddevice` optional for server startup.
 - Rewrote README with explicit virtual environment and one-click bootstrap instructions.
+- One-click installer auto-detects CUDA/ROCm to install matching Torch, `llama-cpp-python`, and GPU extras.

--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -498,3 +498,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** Revisit if the speech endpoint schema changes.
 - **Status:** active
 - **Links:** n/a
+
+### [2025-09-20] one-click-gpu-detection
+
+- **Context:** GPU-equipped systems required manual selection of Torch and `llama-cpp-python` builds, complicating setup.
+- **Decision:** Extend `scripts/one_click.py` to detect CUDA or ROCm and install matching Torch, `llama-cpp-python`, `bitsandbytes`, and `flash-attn` wheels.
+- **Alternatives:** Leave hardware-specific commands in documentation for manual execution.
+- **Trade-offs:** Script embeds URLs that may change upstream and adds more installation logic.
+- **Scope:** `scripts/one_click.py`, `requirements.txt`.
+- **Impact:** Users with NVIDIA or AMD GPUs get optimized dependencies automatically; CPU-only flows remain unchanged.
+- **TTL / Review:** Revisit when PyTorch or `llama-cpp-python` release new wheel indexes.
+- **Status:** active
+- **Links:** goal gpu-aware-one-click

--- a/GOALS.md
+++ b/GOALS.md
@@ -279,3 +279,17 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Scenes:** tests/test_one_click.py::test_miniforge_detection_and_skip
 - **Linked Decisions:** [2025-08-24] miniforge-idempotent
 - **Notes:** re-evaluate if update-through-installer is required
+
+### Capability: gpu-aware-one-click
+
+- **Purpose:** Automatically install GPU-optimized dependencies when hardware is present.
+- **Scope:** `scripts/one_click.py`, `requirements.txt`.
+- **Shape:** Setup detects `nvidia-smi` or `rocm-smi` and installs matching Torch, `llama-cpp-python`, and GPU extras; falls back to CPU wheels otherwise.
+- **Compatibility:** CPU-only systems continue using standard packages.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:**
+  - `tests/test_one_click.py::test_detect_gpu_cuda`
+  - `tests/test_one_click.py::test_install_torch_cuda`
+- **Linked Decisions:** [2025-09-20] one-click-gpu-detection
+- **Notes:** `bitsandbytes` and `flash-attn` installs are best effort.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ python scripts/start.py
 ```
 
 `one_click.py` downloads Miniforge if needed, creates a virtual environment and installs all requirements.
+If `nvidia-smi` or `rocm-smi` is available, it also installs GPU-optimized Torch, `bitsandbytes`, `flash-attn`, and a matching
+`llama-cpp-python` wheel.
 
 The admin dashboard is served at http://localhost:5005/admin.
 

--- a/scripts/one_click.py
+++ b/scripts/one_click.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """One-click environment setup."""
 from __future__ import annotations
-import os
 import platform
 import shutil
 import subprocess
@@ -61,9 +60,64 @@ def install_miniforge(os_name: str, arch: str) -> None:
 def pick_requirements() -> Path:
     return Path(__file__).resolve().parent.parent / "requirements.txt"
 
+def detect_gpu() -> str | None:
+    """Return 'cuda', 'rocm', or None based on available tools."""
+    if shutil.which("nvidia-smi"):
+        return "cuda"
+    if shutil.which("rocm-smi"):
+        return "rocm"
+    return None
+
+
+def install_torch(gpu: str | None) -> None:
+    cmd = [sys.executable, "-m", "pip", "install", "torch"]
+    if gpu == "cuda":
+        cmd += ["--extra-index-url", "https://download.pytorch.org/whl/cu124"]
+    elif gpu == "rocm":
+        cmd += ["--extra-index-url", "https://download.pytorch.org/whl/rocm6.2"]
+    subprocess.check_call(cmd)
+    if gpu is not None:
+        subprocess.check_call(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "bitsandbytes",
+                "flash-attn",
+            ]
+        )
+
+
+def install_llama_cpp(gpu: str | None) -> None:
+    cmd = [sys.executable, "-m", "pip", "install", "llama-cpp-python"]
+    if gpu == "cuda":
+        cmd += [
+            "--extra-index-url",
+            "https://abetlen.github.io/llama-cpp-python/whl/cu124",
+        ]
+    elif gpu == "rocm":
+        cmd += [
+            "--extra-index-url",
+            "https://abetlen.github.io/llama-cpp-python/whl/rocm6.2",
+        ]
+    subprocess.check_call(cmd)
+
+
 def install_requirements(req_file: Path) -> None:
     print(f"Installing dependencies from {req_file}")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", str(req_file)])
+    pkgs: list[str] = []
+    with req_file.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("torch"):
+                continue
+            pkgs.append(line)
+    if pkgs:
+        subprocess.check_call([sys.executable, "-m", "pip", "install", *pkgs])
+    gpu = detect_gpu()
+    install_torch(gpu)
+    install_llama_cpp(gpu)
 
 def main() -> None:
     if not miniforge_installed():

--- a/tests/test_one_click.py
+++ b/tests/test_one_click.py
@@ -4,6 +4,41 @@ from pathlib import Path
 from scripts import one_click
 
 
+def test_detect_gpu_cuda(monkeypatch):
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/usr/bin/nvidia-smi" if name == "nvidia-smi" else None
+    )
+    assert one_click.detect_gpu() == "cuda"
+
+
+def test_detect_gpu_rocm(monkeypatch):
+    monkeypatch.setattr(
+        shutil, "which", lambda name: "/opt/rocm/bin/rocm-smi" if name == "rocm-smi" else None
+    )
+    assert one_click.detect_gpu() == "rocm"
+
+
+def test_install_torch_cuda(monkeypatch):
+    calls = []
+    monkeypatch.setattr(one_click.subprocess, "check_call", lambda cmd: calls.append(cmd))
+    one_click.install_torch("cuda")
+    assert calls[0][-2:] == ["--extra-index-url", "https://download.pytorch.org/whl/cu124"]
+    assert calls[1][4:] == ["bitsandbytes", "flash-attn"]
+
+
+def test_install_llama_cpp_cpu(monkeypatch):
+    calls = []
+    monkeypatch.setattr(one_click.subprocess, "check_call", lambda cmd: calls.append(cmd))
+    one_click.install_llama_cpp(None)
+    assert calls[0] == [
+        one_click.sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "llama-cpp-python",
+    ]
+
+
 def test_miniforge_detection_and_skip(tmp_path, monkeypatch):
     monkeypatch.setattr(shutil, "which", lambda name: None)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)


### PR DESCRIPTION
## Summary
- detect CUDA or ROCm via `nvidia-smi`/`rocm-smi` in `scripts/one_click.py`
- install matching Torch wheel, GPU extras, and `llama-cpp-python` automatically
- document GPU-aware installer and record goal/decision

## Testing
- `pytest tests/test_one_click.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab47942014832ca005044544440eaf