### PR TITLE
Clarify one-click setup instructions

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -19,6 +19,18 @@
 
 _(New entries go on top. Keep each under ~20 lines.)_
 
+### [2025-08-24] one-click-docs
+
+- **Context:** Users were unclear about what `scripts/one_click.py` automates and which setup steps remain manual.
+- **Decision:** Document that the script downloads Miniforge, creates `.venv`, installs `requirements.txt`, and note that GPU-specific wheels and environment activation are still manual.
+- **Alternatives:** Leave the brief description and assume prior knowledge.
+- **Trade-offs:** Slightly longer README section for clearer setup expectations.
+- **Scope:** `README.md`, `DECISIONS.log`.
+- **Impact:** Clarifies setup flow and reduces onboarding friction.
+- **TTL / Review:** Revisit if `one_click.py` gains hardware-specific installation or auto-activation.
+- **Status:** ACTIVE
+- **Links:** n/a
+
 ### [2025-08-24] orpheus-local-none-stop
 
 - **Context:** `_stream_from_model` assumed the underlying iterator raised `StopIteration`; some `orpheus_cpp` iterators instead returned `None`, causing `TypeError` during unpacking.

--- a/README.md
+++ b/README.md
@@ -37,10 +37,20 @@ Play `output.wav` with any media player.
 
 ```bash
 python scripts/one_click.py
+source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
 python scripts/start.py
 ```
 
-`one_click.py` downloads Miniforge if needed, creates a virtual environment and installs all requirements.
+`one_click.py`:
+
+- Downloads Miniforge if needed
+- Creates a `.venv` virtual environment
+- Installs dependencies from `requirements.txt`
+
+You still need to:
+
+- Install GPU-specific PyTorch and accelerator wheels for your hardware
+- Activate the environment as shown above before starting the server
 
 The admin dashboard is served at http://localhost:5005/admin.
 


### PR DESCRIPTION
## WHY
Clarify one-click setup so users know which steps are automated vs manual (goal: centralized-docs).

## OUTCOME
README enumerates what `scripts/one_click.py` handles and explicitly instructs environment activation before starting.

## SURFACES TOUCHED
- README.md
- DECISIONS.log

## EXIT VIA SCENES
- `pytest -q`

## COMPATIBILITY
No code changes; documentation only.

## NO-GO
Abort if tests fail or setup flow changes.


------
https://chatgpt.com/codex/tasks/task_e_68ab47950220832cb40f657a45dbb285