### PR TITLE
Gracefully handle missing dependencies in start script

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -549,3 +549,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** Revisit when PyTorch or `llama-cpp-python` release new wheel indexes.
 - **Status:** active
 - **Links:** goal gpu-aware-one-click
+
+### [2025-08-24] start-dep-checks
+
+- **Context:** The start script raised raw tracebacks when optional dependencies like `python-dotenv` were missing.
+- **Decision:** Wrap imports of `python-dotenv` and `orpheus_cpp` with try/except blocks that exit with guidance to install missing packages.
+- **Alternatives:** Allow ImportErrors to propagate.
+- **Trade-offs:** Slightly more startup code; messages may become outdated.
+- **Scope:** `scripts/start.py`, `tests/test_start_requires_dotenv.py`, `tests/test_start_requires_orpheus_cpp.py`.
+- **Impact:** Users receive clear installation guidance instead of stack traces when dependencies are absent.
+- **TTL / Review:** Review when dependency handling changes.
+- **Status:** active
+- **Links:** n/a

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -8,7 +8,14 @@ if str(ROOT) not in sys.path:
 import os
 import threading
 import webbrowser
-from dotenv import load_dotenv
+
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise SystemExit(
+        "python-dotenv is required to load configuration. Install it with `pip install python-dotenv`."
+    ) from exc
+
 from Morpheus_Client.config import ensure_env_file_exists
 from Morpheus_Client import start_server
 

--- a/tests/test_start_requires_dotenv.py
+++ b/tests/test_start_requires_dotenv.py
@@ -3,18 +3,18 @@ import importlib
 import pytest
 
 
-def test_start_errors_when_orpheus_cpp_missing(monkeypatch):
+def test_start_errors_when_dotenv_missing(monkeypatch):
     real_import = builtins.__import__
 
     def fake_import(name, *args, **kwargs):
-        if name == "orpheus_cpp":
+        if name == "dotenv":
             raise ImportError("missing")
         return real_import(name, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
+    # Ensure module is reloaded even if previously imported
     import sys
     sys.modules.pop("scripts.start", None)
-    start = importlib.import_module("scripts.start")
     with pytest.raises(SystemExit) as exc:
-        start.main()
-    assert "orpheus_cpp is required" in str(exc.value)
+        importlib.import_module("scripts.start")
+    assert "python-dotenv is required" in str(exc.value)


### PR DESCRIPTION
## WHY
Startup crashed with raw ImportErrors when optional deps were missing.

## OUTCOME
Start script exits with clear guidance when `python-dotenv` or `orpheus_cpp` aren't installed; tests capture the messaging.

## SURFACES TOUCHED
- `scripts/start.py`
- `tests/test_start_requires_orpheus_cpp.py`
- `tests/test_start_requires_dotenv.py`
- `DECISIONS.log`

## EXIT VIA SCENES
- `tests/test_start_requires_orpheus_cpp.py::test_start_errors_when_orpheus_cpp_missing`
- `tests/test_start_requires_dotenv.py::test_start_errors_when_dotenv_missing`

## COMPATIBILITY
Additive; behavior unchanged when dependencies exist.

## NO-GO
None identified.

------
https://chatgpt.com/codex/tasks/task_e_68ab4e0ec2fc832cbd2caa4650f5a30b