### PR TITLE
Consolidate one-click dependency install

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -549,3 +549,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **TTL / Review:** Revisit when PyTorch or `llama-cpp-python` release new wheel indexes.
 - **Status:** active
 - **Links:** goal gpu-aware-one-click
+
+### [2025-09-25] one-click-install-consolidation
+
+- **Context:** The one-click script defined two `install_requirements` functions, leaving GPU-aware installs unused and outside the virtual environment.
+- **Decision:** Merge installation logic into a single `install_requirements` that uses the provided Python executable and passes it to GPU package installers.
+- **Alternatives:** Keep both functions and rely on `sys.executable` for GPU installs.
+- **Trade-offs:** Slightly more parameters, but ensures all dependencies install into the correct environment.
+- **Scope:** `scripts/one_click.py`, `tests/test_one_click.py`.
+- **Impact:** One-click setup installs standard and GPU-specific dependencies in the virtual environment.
+- **TTL / Review:** Review when dependency management changes.
+- **Status:** active
+- **Links:** goal gpu-aware-one-click, goal auto-venv-setup

--- a/tests/test_one_click.py
+++ b/tests/test_one_click.py
@@ -23,17 +23,21 @@ def test_detect_gpu_rocm(monkeypatch):
 def test_install_torch_cuda(monkeypatch):
     calls = []
     monkeypatch.setattr(one_click.subprocess, "check_call", lambda cmd: calls.append(cmd))
-    one_click.install_torch("cuda")
+    python = Path("/tmp/python")
+    one_click.install_torch(python, "cuda")
+    assert calls[0][0] == str(python)
     assert calls[0][-2:] == ["--extra-index-url", "https://download.pytorch.org/whl/cu124"]
+    assert calls[1][0] == str(python)
     assert calls[1][4:] == ["bitsandbytes", "flash-attn"]
 
 
 def test_install_llama_cpp_cpu(monkeypatch):
     calls = []
     monkeypatch.setattr(one_click.subprocess, "check_call", lambda cmd: calls.append(cmd))
-    one_click.install_llama_cpp(None)
+    python = Path("/tmp/python")
+    one_click.install_llama_cpp(python, None)
     assert calls[0] == [
-        one_click.sys.executable,
+        str(python),
         "-m",
         "pip",
         "install",
@@ -76,4 +80,4 @@ def test_install_requirements_uses_given_python(tmp_path, monkeypatch):
     monkeypatch.setattr(one_click.subprocess, "check_call", fake_call)
     python = tmp_path / "custom" / "python"
     one_click.install_requirements(python, req)
-    assert calls[0][0] == str(python)
+    assert all(c[0] == str(python) for c in calls)


### PR DESCRIPTION
## WHY
Bring `gpu-aware-one-click` in line with `auto-venv-setup` by ensuring GPU-specific dependencies install via the virtual environment.

## OUTCOME
Running `scripts/one_click.py` installs both standard and GPU-specific dependencies using the venv's Python, eliminating redundant logic.

## SURFACES TOUCHED
- `scripts/one_click.py`
- `tests/test_one_click.py`
- `DECISIONS.log`

## EXIT VIA SCENES
- `tests/test_one_click.py::test_detect_gpu_cuda`
- `tests/test_one_click.py::test_install_torch_cuda`
- `tests/test_one_click.py::test_install_llama_cpp_cpu`
- `tests/test_one_click.py::test_miniforge_detection_and_skip`
- `tests/test_one_click.py::test_ensure_venv_creates_and_returns_python`
- `tests/test_one_click.py::test_install_requirements_uses_given_python`

## COMPATIBILITY
CPU-only systems still install CPU wheels; no flags added.

## NO-GO
Abort if dependency installation fails or GPU wheel indexes drift.


------
https://chatgpt.com/codex/tasks/task_e_68ab4e06676c832c924bc59909df5c6e