### PR TITLE
feat: guide missing start dependencies

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -20,6 +20,18 @@
 _(New entries go on top. Keep each under ~20 lines.)_
 
 
+### [2025-12-10] start-dep-errors
+
+- **Context:** Importing `python-dotenv` or `orpheus_cpp` in `scripts/start.py` produced full tracebacks when missing.
+- **Decision:** Catch `ImportError` for these dependencies and exit with installation guidance, suppressing traceback chaining.
+- **Alternatives:** Allow raw `ImportError` to surface.
+- **Trade-offs:** Hides debugging detail at startup in favor of clarity for missing dependencies.
+- **Scope:** `scripts/start.py`, `tests/test_start_requires_dotenv.py`, `tests/test_start_requires_orpheus_cpp.py`.
+- **Impact:** Users see concise `pip install` instructions instead of stack traces.
+- **TTL / Review:** Revisit if dependency management or messaging changes.
+- **Status:** ACTIVE
+- **Links:** goal dotenv-startup-check, goal orpheus-cpp-startup-check
+
 ### [2025-12-09] canonical-installer
 
 - **Context:** Having both `scripts/install.py` and `scripts/one_click.py` caused confusion about the supported setup path.

--- a/GOALS.md
+++ b/GOALS.md
@@ -207,6 +207,18 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Decisions:** [2025-09-30] orpheus-cpp-required
 - **Notes:** build step may take several minutes
 
+### Capability: dotenv-startup-check
+
+- **Purpose:** Exit early with guidance when `python-dotenv` is missing.
+- **Scope:** `scripts/start.py`.
+- **Shape:** Importing the start script without `python-dotenv` raises a descriptive `SystemExit` message.
+- **Compatibility:** additive; start script aborts before configuration.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `tests/test_start_requires_dotenv.py`
+- **Linked Decisions:** [2025-08-24] start-dep-checks
+- **Notes:** none
+
 ### Capability: transcript-history
 
 - **Purpose:** Retain utterance text for replay and monitoring.

--- a/scripts/start.py
+++ b/scripts/start.py
@@ -11,10 +11,10 @@ import webbrowser
 
 try:  # pragma: no cover - optional dependency
     from dotenv import load_dotenv
-except ImportError as exc:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     raise SystemExit(
-        "python-dotenv is required to load configuration. Install it with `pip install python-dotenv`."
-    ) from exc
+        "Install `python-dotenv` via `pip install python-dotenv` to load configuration."
+    )
 
 from Morpheus_Client.config import ensure_env_file_exists
 from Morpheus_Client import start_server
@@ -30,10 +30,10 @@ def main() -> None:
     """
     try:
         import orpheus_cpp  # noqa: F401
-    except ImportError as exc:  # pragma: no cover - depends on optional dep
+    except ImportError:  # pragma: no cover - depends on optional dep
         raise SystemExit(
-            "orpheus_cpp is required for local synthesis. Install it with `pip install orpheus-cpp`."
-        ) from exc
+            "Install `orpheus_cpp` via `pip install orpheus-cpp` for local synthesis."
+        )
     ensure_env_file_exists()
     # Load config files: OS env > ~/.morpheus/config > .env
     user_config = os.path.expanduser("~/.morpheus/config")

--- a/tests/test_start_requires_dotenv.py
+++ b/tests/test_start_requires_dotenv.py
@@ -17,4 +17,6 @@ def test_start_errors_when_dotenv_missing(monkeypatch):
     sys.modules.pop("scripts.start", None)
     with pytest.raises(SystemExit) as exc:
         importlib.import_module("scripts.start")
-    assert "python-dotenv is required" in str(exc.value)
+    msg = str(exc.value)
+    assert "pip install python-dotenv" in msg
+    assert exc.value.__cause__ is None

--- a/tests/test_start_requires_orpheus_cpp.py
+++ b/tests/test_start_requires_orpheus_cpp.py
@@ -17,4 +17,6 @@ def test_start_errors_when_orpheus_cpp_missing(monkeypatch):
     start = importlib.import_module("scripts.start")
     with pytest.raises(SystemExit) as exc:
         start.main()
-    assert "orpheus_cpp is required" in str(exc.value)
+    msg = str(exc.value)
+    assert "pip install orpheus-cpp" in msg
+    assert exc.value.__cause__ is None


### PR DESCRIPTION
## WHY
- users saw full tracebacks when optional imports failed

## OUTCOME
- start script exits with clear `pip install` guidance when `python-dotenv` or `orpheus_cpp` are missing

## SURFACES TOUCHED
- `scripts/start.py`
- `tests/test_start_requires_dotenv.py`
- `tests/test_start_requires_orpheus_cpp.py`
- `GOALS.md`
- `DECISIONS.log`

## EXIT VIA SCENES
- `tests/test_start_requires_dotenv.py`
- `tests/test_start_requires_orpheus_cpp.py`

## COMPATIBILITY
- additive; start script aborts before configuration if dependencies are absent

## NO-GO
- dependency names change or become unavailable


------
https://chatgpt.com/codex/tasks/task_e_68ab514f1800832c8de77a156359cacc