### PR TITLE
Validate requirements during CI

### DIFF
--- a/.github/workflows/scenario-probes.yml
+++ b/.github/workflows/scenario-probes.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'
+      - name: Validate requirements
+        run: python scripts/validate_requirements.py
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -623,3 +623,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** goal dependency-lock
 
+### [2025-12-10] requirements-ci-validation
+
+- **Context:** Dependency conflicts may merge unnoticed until runtime, slowing feedback cycles.
+- **Decision:** Add `scripts/validate_requirements.py` and invoke it in CI to install `requirements.txt` in an isolated environment.
+- **Alternatives:** Rely on main workflow installs or manual checks.
+- **Trade-offs:** Slight increase in CI time and repository maintenance.
+- **Scope:** `scripts/validate_requirements.py`, `.github/workflows/scenario-probes.yml`, `GOALS.md`.
+- **Impact:** Pull requests fail early when `pip install -r requirements.txt` cannot resolve dependencies.
+- **TTL / Review:** Revisit if dependency management moves to a lockfile or different tool.
+- **Status:** active
+- **Links:** goal ci-requirements-validation
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -346,3 +346,15 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Decisions:** pin-core-dependencies
 - **Notes:** pins numpy <2 to match torch wheels.
 
+### Capability: ci-requirements-validation
+
+- **Purpose:** Fail early when dependency resolution breaks.
+- **Scope:** `scripts/validate_requirements.py`, `.github/workflows/scenario-probes.yml`.
+- **Shape:** `scripts/validate_requirements.py` installs `requirements.txt` in a fresh virtual environment; workflow fails on errors.
+- **Compatibility:** additive; no impact on runtime environments.
+- **Status:** active
+- **Owner:** repository owner
+- **Linked Scenes:** `.github/workflows/scenario-probes.yml`
+- **Linked Decisions:** [2025-12-10] requirements-ci-validation
+- **Notes:** none
+

--- a/scripts/validate_requirements.py
+++ b/scripts/validate_requirements.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Validate that requirements.txt installs in a clean environment."""
+from __future__ import annotations
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    req_file = repo_root / "requirements.txt"
+    with tempfile.TemporaryDirectory() as tmp:
+        venv_dir = Path(tmp) / "venv"
+        subprocess.check_call([sys.executable, "-m", "venv", str(venv_dir)])
+        if os.name == "nt":
+            python = venv_dir / "Scripts" / "python.exe"
+        else:
+            python = venv_dir / "bin" / "python"
+        try:
+            subprocess.check_call([str(python), "-m", "pip", "install", "--upgrade", "pip"])
+            subprocess.check_call([str(python), "-m", "pip", "install", "-r", str(req_file)])
+        except subprocess.CalledProcessError:
+            print("Dependency installation failed", file=sys.stderr)
+            return 1
+    print("Dependency installation succeeded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Task
- **WHY:** ensure dependency resolution errors are caught automatically
- **OUTCOME:** pull requests fail when `pip install -r requirements.txt` cannot resolve
- **SURFACES TOUCHED:** `scripts/validate_requirements.py`, `.github/workflows/scenario-probes.yml`, `GOALS.md`, `DECISIONS.log`
- **EXIT VIA SCENES:** `python scripts/validate_requirements.py`, `scripts/run_tests.sh`
- **COMPATIBILITY:** additive; no runtime impact
- **NO-GO:** dependency installation fails

## Summary
- add script that installs `requirements.txt` in a temporary venv and reports failures
- invoke requirements validation in the scenario-probes workflow
- record capability and decision for CI dependency validation

## Testing
- ⚠️ `python scripts/validate_requirements.py` (interrupted during pip upgrade)
- ⚠️ `scripts/run_tests.sh` (missing `Orpheus-TTS/orpheus_tts_pypi/pyproject.toml`)


------
https://chatgpt.com/codex/tasks/task_e_68ab5ac8f3e0832cae1a79be2ff326cf