### PR TITLE
chore: use archived Orpheus-TTS for tests

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -635,3 +635,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:** goal ci-requirements-validation
 
+### [2025-08-24] run-tests-archive-path
+
+- **Context:** `scripts/run_tests.sh` installed Orpheus-TTS dependencies from a non-archived path.
+- **Decision:** Read Orpheus-TTS dependencies from an archived `pyproject.toml` and allow an `ARCHIVE_ROOT` override.
+- **Alternatives:** Hardcode the new path or rely on live repository layout.
+- **Trade-offs:** Adds an environment variable but keeps the test runner resilient to archive moves.
+- **Scope:** `scripts/run_tests.sh`.
+- **Impact:** Test runs install Orpheus-TTS from the archive by default.
+- **TTL / Review:** Revisit if archive structure or dependency management changes.
+- **Status:** active
+- **Links:**
+

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,7 +2,9 @@
 # Fire-and-forget test runner
 
 set -euo pipefail
+
+ARCHIVE_ROOT=${ARCHIVE_ROOT:-archive}
 export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
-uv pip install --system -r Orpheus-TTS/orpheus_tts_pypi/pyproject.toml
+uv pip install --system -r "${ARCHIVE_ROOT}/Orpheus-TTS/orpheus_tts_pypi/pyproject.toml"
 python -m pytest -q "$@"
 


### PR DESCRIPTION
## WHY
scripts/run_tests.sh referenced a stale Orpheus-TTS path, causing dependency installation failures.

## OUTCOME
the test runner installs Orpheus-TTS dependencies from the archived repository by default and allows overriding the archive root.

## SURFACES TOUCHED
- scripts/run_tests.sh
- DECISIONS.log

## EXIT VIA SCENES
- scripts/run_tests.sh

## COMPATIBILITY
- No breaking changes; ARCHIVE_ROOT env var can point to alternative locations.

## NO-GO
- Abort if dependency installation fails or archive layout differs.


------
https://chatgpt.com/codex/tasks/task_e_68ab5c8677a8832c90e951e8b0140383