### PR TITLE
feat: configure orpheus context via env

### DIFF
--- a/DECISIONS.log
+++ b/DECISIONS.log
@@ -647,3 +647,15 @@ _(New entries go on top. Keep each under ~20 lines.)_
 - **Status:** active
 - **Links:**
 
+### [2025-12-17] orpheus-default-n-ctx
+
+- **Context:** The local Orpheus TTS adapter instantiated `OrpheusCpp` without a context length, causing `Failed to create llama_context`.
+- **Decision:** Read `ORPHEUS_N_CTX` and `ORPHEUS_N_GPU_LAYERS` environment variables and pass them to `OrpheusCpp`, defaulting to `n_ctx=8192` and `n_gpu_layers=0`.
+- **Alternatives:** Modify the `orpheus_cpp` package upstream.
+- **Trade-offs:** Adds environment variables; requires reload when changing values.
+- **Scope:** `Morpheus_Client/tts_engine/orpheus_local.py`, `tests/test_orpheus_model_config.py`, `GOALS.md`, `INTERFACES.md`.
+- **Impact:** Local TTS starts on CPU and can offload layers to GPU when configured.
+- **TTL / Review:** Revisit if upstream exposes defaults.
+- **Status:** active
+- **Links:** goal configurable-orpheus-context
+

--- a/GOALS.md
+++ b/GOALS.md
@@ -358,3 +358,15 @@ _(Append new capabilities below using the format above. Keep the list curated; c
 - **Linked Decisions:** [2025-12-10] requirements-ci-validation
 - **Notes:** none
 
+### Capability: configurable-orpheus-context
+
+- **Purpose:** Allow local TTS to set context length and GPU layer count to avoid llama context creation failures.
+- **Scope:** `Morpheus_Client/tts_engine/orpheus_local.py`
+- **Shape:** `_load_model_sync` reads `ORPHEUS_N_CTX` and `ORPHEUS_N_GPU_LAYERS`; defaults `n_ctx` to 8192.
+- **Compatibility:** defaults maintain previous behaviour when vars unset.
+- **Status:** active
+- **Owner:** repo owner
+- **Linked Scenes:** `tests/test_orpheus_model_config.py`
+- **Linked Decisions:** [2025-12-17] orpheus-default-n-ctx
+- **Notes:** ensures TTS runs on CPU when GPU config missing
+

--- a/INTERFACES.md
+++ b/INTERFACES.md
@@ -93,6 +93,7 @@
   - 2025-10-24: allow `source_config` for constructor options
   - 2025-08-19: mirror config to `~/.morpheus/config` and load it before `.env`
   - 2025-10-30: validate and persist `ORPHEUS_TEMPERATURE`, `ORPHEUS_TOP_P`, `ORPHEUS_MAX_TOKENS`
+  - 2025-12-17: allow `ORPHEUS_N_CTX` and `ORPHEUS_N_GPU_LAYERS` for local TTS model
 
 ### Surface: admin-endpoint
 - **Type:** API

--- a/Morpheus_Client/tts_engine/orpheus_local.py
+++ b/Morpheus_Client/tts_engine/orpheus_local.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 from functools import lru_cache
 from typing import AsyncGenerator, Optional, TYPE_CHECKING
+import os
 
 from ..orchestrator.adapter import (
     AudioChunk,
@@ -40,9 +41,15 @@ def _load_model_sync() -> "OrpheusCpp":
 
     from orpheus_cpp import OrpheusCpp
 
-    # ``verbose`` is disabled to keep logs clean during tests; language is fixed
-    # to English which matches the default voice set.
-    return OrpheusCpp(verbose=False, lang="en")
+    n_ctx = int(os.environ.get("ORPHEUS_N_CTX", "8192"))
+    n_gpu_layers = int(os.environ.get("ORPHEUS_N_GPU_LAYERS", "0"))
+
+    return OrpheusCpp(
+        verbose=False,
+        lang="en",
+        n_ctx=n_ctx,
+        n_gpu_layers=n_gpu_layers,
+    )
 
 
 async def _load_model() -> "OrpheusCpp":

--- a/tests/test_orpheus_model_config.py
+++ b/tests/test_orpheus_model_config.py
@@ -1,0 +1,52 @@
+import importlib
+import os
+import sys
+import types
+
+
+def make_dummy(record):
+    class Dummy:
+        def __init__(self, *, verbose, lang, n_ctx, n_gpu_layers):
+            record.update(
+                verbose=verbose,
+                lang=lang,
+                n_ctx=n_ctx,
+                n_gpu_layers=n_gpu_layers,
+            )
+    return Dummy
+
+
+def test_load_model_sync_uses_env(monkeypatch):
+    record = {}
+    dummy_module = types.SimpleNamespace(OrpheusCpp=make_dummy(record))
+    monkeypatch.setenv("ORPHEUS_N_CTX", "1234")
+    monkeypatch.setenv("ORPHEUS_N_GPU_LAYERS", "5")
+    monkeypatch.setitem(sys.modules, "orpheus_cpp", dummy_module)
+    import Morpheus_Client.tts_engine.orpheus_local as orpheus_local
+    importlib.reload(orpheus_local)
+    orpheus_local._load_model_sync.cache_clear()
+    orpheus_local._load_model_sync()
+    assert record == {
+        "verbose": False,
+        "lang": "en",
+        "n_ctx": 1234,
+        "n_gpu_layers": 5,
+    }
+
+
+def test_load_model_sync_defaults(monkeypatch):
+    record = {}
+    dummy_module = types.SimpleNamespace(OrpheusCpp=make_dummy(record))
+    monkeypatch.delenv("ORPHEUS_N_CTX", raising=False)
+    monkeypatch.delenv("ORPHEUS_N_GPU_LAYERS", raising=False)
+    monkeypatch.setitem(sys.modules, "orpheus_cpp", dummy_module)
+    import Morpheus_Client.tts_engine.orpheus_local as orpheus_local
+    importlib.reload(orpheus_local)
+    orpheus_local._load_model_sync.cache_clear()
+    orpheus_local._load_model_sync()
+    assert record == {
+        "verbose": False,
+        "lang": "en",
+        "n_ctx": 8192,
+        "n_gpu_layers": 0,
+    }


### PR DESCRIPTION
## Task
- **WHY**: server crashed because OrpheusCpp was instantiated with `n_ctx=0`, failing to create a llama context
- **OUTCOME**: local TTS adapter reads `ORPHEUS_N_CTX` and `ORPHEUS_N_GPU_LAYERS`, defaulting to 8192/0 so the model loads on CPU and can offload layers when configured
- **SURFACES TOUCHED**: `Morpheus_Client/tts_engine/orpheus_local.py`, `tests/test_orpheus_model_config.py`, `GOALS.md`, `DECISIONS.log`, `INTERFACES.md`
- **EXIT VIA SCENES**: `tests/test_tts_adapter_chunking.py`, `tests/test_stream_from_model_none_termination.py`, `tests/test_orpheus_model_config.py`
- **COMPATIBILITY**: falls back to existing behaviour when env vars absent
- **NO-GO**: abort if OrpheusCpp API drops `n_ctx`/`n_gpu_layers`

## Summary
- allow `_load_model_sync` to read `ORPHEUS_N_CTX` and `ORPHEUS_N_GPU_LAYERS` and pass them to `OrpheusCpp`
- document configurable context in GOALS, DECISIONS, INTERFACES
- add tests covering default and env-based configuration

## Testing
- `pytest tests/test_tts_adapter_chunking.py tests/test_stream_from_model_none_termination.py tests/test_orpheus_model_config.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab62a1fc68832c9d2ff771c9e76c83